### PR TITLE
Profile

### DIFF
--- a/archinstall.py
+++ b/archinstall.py
@@ -23,7 +23,7 @@ positionals = []
 for arg in sys.argv[1:]:
 	if '--' == arg[:2]:
 		if '=' in arg:
-			key, val = [strip(x) for x in arg[2:].split('=')]
+			key, val = [x.strip() for x in arg[2:].split('=')]
 		else:
 			key, val = arg[2:], True
 		args[key] = val


### PR DESCRIPTION
Archinstall will no longer auto-wipe the disk unless `--default` is given.
It also takes `--profile="profile name"` as a argument so that manually inputting a desired template can be skipped.

yubikey "support" is on the way too.