### PR TITLE
Fixed git self-updated & Created support for pseudo-booting the installed OS

### DIFF
--- a/archinstall.py
+++ b/archinstall.py
@@ -172,15 +172,18 @@ class sys_command():
 							print('[N] Writing to subsystem: {}'.format(self.opts['triggers'][trigger]))
 							os.write(child_fd, self.opts['triggers'][trigger])
 							del(self.opts['triggers'][trigger])
+
+					## Adding a exit trigger:
 					if len(self.opts['triggers']) == 0:
-						alive = False
-						break
+						if b'[root@arcinstall ~]#' in output:
+							alive = False
+							break
 
 				yield output
 
 		# Since we're in a subsystem, we gotta bail out!
 		# Bail bail bail!
-		os.write(child_fd, b'shutdown now')
+		os.write(child_fd, b'shutdown now\n')
 
 		exit_code = os.waitpid(self.pid, 0)[1]
 		if exit_code != 0:

--- a/archinstall.py
+++ b/archinstall.py
@@ -168,12 +168,19 @@ class sys_command():
 				lower = output.lower()
 				if 'triggers' in self.opts:
 					for trigger in self.opts['triggers']:
-						print(trigger.lower(),'vs', lower)
 						if trigger.lower() in lower:
 							print('[N] Writing to subsystem: {}'.format(self.opts['triggers'][trigger]))
 							os.write(child_fd, self.opts['triggers'][trigger])
+							del(self.opts['triggers'][trigger])
+					if len(self.opts['triggers']) == 0:
+						alive = False
+						break
 
 				yield output
+
+		# Since we're in a subsystem, we gotta bail out!
+		# Bail bail bail!
+		os.write(child_fd, b'shutdown now')
 
 		exit_code = os.waitpid(self.pid, 0)[1]
 		if exit_code != 0:

--- a/archinstall.py
+++ b/archinstall.py
@@ -170,6 +170,7 @@ class sys_command():
 					for trigger in self.opts['triggers']:
 						print(trigger.lower(),'vs', lower)
 						if trigger.lower() in lower:
+							print('[N] Writing to subsystem: {}'.format(trigger))
 							os.write(child_fd, self.opts['triggers'][trigger])
 
 				yield output

--- a/archinstall.py
+++ b/archinstall.py
@@ -136,7 +136,7 @@ class sys_command():
 
 	def exec(self):
 		if not self.cmd[0][0] == '/':
-			print('[N] Command is not executed with absolute path, trying to find it..')
+			print('[N] Command is not executed with absolute path, trying to find: {}'.format(self.cmd[0]))
 			o = b''.join(sys_command('/usr/bin/whereis {}'.format(self.cmd[0])).exec())
 			self.cmd[0] = o.split(b' ')[1].decode('UTF-8')
 			print('[N] This is what I\'m going with: {}'.format(self.cmd[0]))

--- a/archinstall.py
+++ b/archinstall.py
@@ -194,12 +194,12 @@ def update_git():
 	default_gw = get_default_gateway_linux()
 	if(default_gw):
 		## Not the most elegant way to make sure git conflicts doesn't occur (yea fml)
-		#os.remove('/root/archinstall/archinstall.py')
-		#os.remove('/root/archinstall/README.md')
+		os.remove('/root/archinstall/archinstall.py')
+		os.remove('/root/archinstall/README.md')
 
 		output = sys_command('(cd /root/archinstall; git fetch --all)') # git reset --hard origin/<branch_name>
 		
-		if b'error:' in output:
+		if b'error:' in b''.join(output):
 			print('[N] Could not update git source for some reason.')
 			return
 
@@ -447,19 +447,19 @@ if __name__ == '__main__':
 	# TODO: --use-random instead of --use-urandom
 	print('[N] Adding encryption to {drive}{partition_2}.'.format(**args))
 	o = sys_command('cryptsetup -q -v --type luks2 --pbkdf argon2i --hash sha512 --key-size 512 --iter-time 10000 --key-file {pwfile} --use-urandom luksFormat {drive}{partition_2}'.format(**args)).exec()
-	if not 'Command successful.' in o.decode('UTF-8').strip():
+	if not 'Command successful.' in b''.join(o).decode('UTF-8').strip():
 		print('[E] Failed to setup disk encryption.', o)
 		exit(1)
 
 	o = sys_command('cryptsetup open {drive}{partition_2} luksdev --key-file {pwfile} --type luks2'.format(**args)).exec()
 	o = sys_command('file /dev/mapper/luksdev').exec() # /dev/dm-0
-	if b'cannot open' in o:
+	if b'cannot open' in b''.join(o):
 		print('[E] Could not mount encrypted device.', o)
 		exit(1)
 
 	print('[N] Creating btrfs filesystem inside {drive}{partition_2}'.format(**args))
 	o = sys_command('mkfs.btrfs /dev/mapper/luksdev').exec()
-	if not b'UUID' in o:
+	if not b'UUID' in b''.join(o):
 		print('[E] Could not setup btrfs filesystem.', o)
 		exit(1)
 	o = sys_command('mount /dev/mapper/luksdev /mnt').exec()

--- a/archinstall.py
+++ b/archinstall.py
@@ -137,7 +137,7 @@ class sys_command():
 	def exec(self):
 		if not self.cmd[0][0] == '/':
 			print('[N] Command is not executed with absolute path, trying to find it..')
-			o = b''.join(sys_command('/usr/bin/whereis {}'.format(self.cmd[0])))
+			o = b''.join(sys_command('/usr/bin/whereis {}'.format(self.cmd[0])).exec())
 			self.cmd[0] = o.split(b' ', 1)[0].decode('UTF-8')
 			print('[N] This is what I\'m going with: {}'.format(self.cmd[0]))
 		# PID = 0 for child, and the PID of the child for the parent    
@@ -204,7 +204,7 @@ def update_git():
 		os.remove('/root/archinstall/archinstall.py')
 		os.remove('/root/archinstall/README.md')
 
-		output = b''.join(sys_command('(cd /root/archinstall; git update)').exec()) # git reset --hard origin/<branch_name> / git fetch --all
+		output = b''.join(sys_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2))').exec()) # git reset --hard origin/<branch_name> / git fetch --all
 		print(output)
 
 		if b'error:' in output:
@@ -220,6 +220,7 @@ def update_git():
 				## Reboot the script (in same context)
 				print('[N] Rebooting the script')
 				os.execv('/usr/bin/python3', ['archinstall.py'] + sys.argv)
+				extit(1)
 
 def device_state(name):
 	# Based out of: https://askubuntu.com/questions/528690/how-to-get-list-of-all-non-removable-disk-device-names-ssd-hdd-and-sata-ide-onl/528709#528709

--- a/archinstall.py
+++ b/archinstall.py
@@ -197,9 +197,9 @@ def update_git():
 		os.remove('/root/archinstall/archinstall.py')
 		os.remove('/root/archinstall/README.md')
 
-		output = sys_command('(cd /root/archinstall; git fetch --all)').exec() # git reset --hard origin/<branch_name>
+		output = b''.join(sys_command('(cd /root/archinstall; git fetch --all)').exec()) # git reset --hard origin/<branch_name>
 		
-		if b'error:' in b''.join(output):
+		if b'error:' in output:
 			print('[N] Could not update git source for some reason.')
 			return
 

--- a/archinstall.py
+++ b/archinstall.py
@@ -205,7 +205,8 @@ def update_git():
 		os.remove('/root/archinstall/README.md')
 
 		output = b''.join(sys_command('(cd /root/archinstall; git update)').exec()) # git reset --hard origin/<branch_name> / git fetch --all
-		
+		print(output)
+
 		if b'error:' in output:
 			print('[N] Could not update git source for some reason.')
 			return

--- a/archinstall.py
+++ b/archinstall.py
@@ -200,8 +200,10 @@ def update_git():
 	if(default_gw):
 		print('[N] Updating git!')
 		## Not the most elegant way to make sure git conflicts doesn't occur (yea fml)
-		os.remove('/root/archinstall/archinstall.py')
-		os.remove('/root/archinstall/README.md')
+		if os.path.isfile('/root/archinstall/archinstall.py'):
+			os.remove('/root/archinstall/archinstall.py')
+		if os.path.isfile('/root/archinstall/README.md'):
+			os.remove('/root/archinstall/README.md')
 
 		simple_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2))') # git reset --hard origin/<branch_name> / git fetch --all
 		print(output)

--- a/archinstall.py
+++ b/archinstall.py
@@ -173,6 +173,7 @@ class sys_command():
 		exit_code = os.waitpid(self.pid, 0)[1]
 		if exit_code != 0:
 			print('[E] Command "{}" exited with status code:'.format(self.cmd[0]), exit_code)
+			exit(1)
 
 def simple_command(cmd, opts=None, *args, **kwargs):
 	if not opts: opts = {}
@@ -206,22 +207,22 @@ def update_git():
 			os.remove('/root/archinstall/README.md')
 
 		output = simple_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2); git pull)')
-		print(output)
 
 		if b'error:' in output:
 			print('[N] Could not update git source for some reason.')
 			return
 
 		# b'From github.com:Torxed/archinstall\n   339d687..80b97f3  master     -> origin/master\nUpdating 339d687..80b97f3\nFast-forward\n README.md | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n'
-		tmp = re.findall(b'[0-9]+ file changed', output)
-		print(tmp)
-		if len(tmp):
-			num_changes = int(tmp[0].split(b' ',1)[0])
-			if(num_changes):
-				## Reboot the script (in same context)
-				print('[N] Rebooting the script')
-				os.execv('/usr/bin/python3', ['archinstall.py'] + sys.argv)
-				extit(1)
+		if not b'Already up to date' in output:
+			tmp = re.findall(b'[0-9]+ file changed', output)
+			print(tmp)
+			if len(tmp):
+				num_changes = int(tmp[0].split(b' ',1)[0])
+				if(num_changes):
+					## Reboot the script (in same context)
+					print('[N] Rebooting the script')
+					os.execv('/usr/bin/python3', ['archinstall.py'] + sys.argv)
+					extit(1)
 
 def device_state(name):
 	# Based out of: https://askubuntu.com/questions/528690/how-to-get-list-of-all-non-removable-disk-device-names-ssd-hdd-and-sata-ide-onl/528709#528709

--- a/archinstall.py
+++ b/archinstall.py
@@ -629,7 +629,7 @@ if __name__ == '__main__':
 			## Either skipping mounting /run and using traditional chroot is an option, but using
 			## `systemd-nspawn -D /mnt --machine temporary` might be a more flexible solution in case of file structure changes.
 			if 'no-chroot' in opts and opts['no-chroot']:
-				o = b''.join(sys_command(command, opts).exec())
+				o = simple_command(command, opts)
 			elif 'chroot' in opts and opts['chroot']:
 				## Run in a manually set up version of arch-chroot (arch-chroot will break namespaces).
 				## This is a bit risky in case the file systems changes over the years, but we'll probably be safe adding this as an option.

--- a/archinstall.py
+++ b/archinstall.py
@@ -638,7 +638,11 @@ if __name__ == '__main__':
 					# 	fh.write('ExecStart=-/usr/bin/agetty --autologin root -s %I 115200,38400,9600 vt102\n')
 
 					## And then boot and execute:
-					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {b'Graphical Interface' : bytes(command, 'UTF-8')}, **opts}).exec())
+					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
+																												b'Archinstall login:' : b'root',
+																												b'Password' : bytes(args['password'], 'UTF-8'),
+																												b'root#' : bytes(command, 'UTF-8'),
+																											}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..
 					# os.remove('/mnt/etc/systemd/system/console-getty.service.d/override.conf')

--- a/archinstall.py
+++ b/archinstall.py
@@ -642,9 +642,9 @@ if __name__ == '__main__':
 
 					## And then boot and execute:
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
-																												b'Archinstall login' : b'root',
-																												b'Password' : bytes(args['password'], 'UTF-8'),
-																												b'root#' : bytes(command, 'UTF-8'),
+																												b'Archinstall login' : b'root\n',
+																												b'Password' : bytes(args['password']+'\n', 'UTF-8'),
+																												b'root#' : bytes(command+'\n', 'UTF-8'),
 																											}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..

--- a/archinstall.py
+++ b/archinstall.py
@@ -638,7 +638,7 @@ if __name__ == '__main__':
 						fh.write('ExecStart=-/usr/bin/agetty --autologin root -s %I 115200,38400,9600 vt102\n')
 
 					## And then boot and execute:
-					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {b'Graphical Interface' : command}, **opts}).exec())
+					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {b'Graphical Interface' : bytes(command, 'UTF-8')}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..
 					os.remove('/mnt/etc/systemd/system/console-getty.service.d/override.conf')

--- a/archinstall.py
+++ b/archinstall.py
@@ -165,7 +165,8 @@ class sys_command():
 
 				yield output
 
-		os.waitpid(self.pid, 0)
+		x = os.waitpid(self.pid, 0)
+		print('Exited with:', x)
 
 # def sys_command(cmd, echo=False, opts=None, *args, **kwargs):
 # 	if not opts: opts = {}
@@ -198,7 +199,7 @@ def update_git():
 		os.remove('/root/archinstall/archinstall.py')
 		os.remove('/root/archinstall/README.md')
 
-		output = b''.join(sys_command('(cd /root/archinstall; git update)').exec()) # git reset --hard origin/<branch_name>
+		output = b''.join(sys_command('(cd /root/archinstall; git update)').exec()) # git reset --hard origin/<branch_name> / git fetch --all
 		
 		if b'error:' in output:
 			print('[N] Could not update git source for some reason.')
@@ -206,6 +207,7 @@ def update_git():
 
 		# b'From github.com:Torxed/archinstall\n   339d687..80b97f3  master     -> origin/master\nUpdating 339d687..80b97f3\nFast-forward\n README.md | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n'
 		tmp = re.findall(b'[0-9]+ file changed', output)
+		print(tmp)
 		if len(tmp):
 			num_changes = int(tmp[0].split(b' ',1)[0])
 			if(num_changes):

--- a/archinstall.py
+++ b/archinstall.py
@@ -205,7 +205,7 @@ def update_git():
 		if os.path.isfile('/root/archinstall/README.md'):
 			os.remove('/root/archinstall/README.md')
 
-		output = simple_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2))') # git reset --hard origin/<branch_name> / git fetch --all
+		output = simple_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2); git pull)')
 		print(output)
 
 		if b'error:' in output:
@@ -466,8 +466,8 @@ if __name__ == '__main__':
 		exit(1)
 
 	o = sys_command('/usr/bin/cryptsetup open {drive}{partition_2} luksdev --key-file {pwfile} --type luks2'.format(**args)).exec()
-	o = sys_command('/usr/bin/file /dev/mapper/luksdev').exec() # /dev/dm-0
-	if b'cannot open' in b''.join(o):
+	o = b''.join(sys_command('/usr/bin/file /dev/mapper/luksdev').exec()) # /dev/dm-0
+	if b'cannot open' in o:
 		print('[E] Could not mount encrypted device.', o)
 		exit(1)
 

--- a/archinstall.py
+++ b/archinstall.py
@@ -155,7 +155,7 @@ class sys_command():
 		while alive:
 			for fileno, event in poller.poll(0.1):
 				try:
-					output = os.read(child_fd, 1024).strip()
+					output = os.read(child_fd, 8192).strip()
 					trace_log += output
 				except OSError:
 					alive = False
@@ -638,7 +638,7 @@ if __name__ == '__main__':
 						fh.write('ExecStart=-/usr/bin/agetty --autologin root -s %I 115200,38400,9600 vt102\n')
 
 					## And then boot and execute:
-					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary {c}'.format(c=command), opts=opts).exec())
+					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {b'Graphical Interface' : command}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..
 					os.remove('/mnt/etc/systemd/system/console-getty.service.d/override.conf')

--- a/archinstall.py
+++ b/archinstall.py
@@ -644,7 +644,7 @@ if __name__ == '__main__':
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
 																												b'Arcinstall login' : b'root\n',
 																												b'Password' : bytes(args['password']+'\n', 'UTF-8'),
-																												b'root#' : bytes(command+'\n', 'UTF-8'),
+																												b'[root@Archinstall ~]#' : bytes(command+'\n', 'UTF-8'),
 																											}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..

--- a/archinstall.py
+++ b/archinstall.py
@@ -249,7 +249,10 @@ def grab_partitions(dev):
 		##       and make sys_command() return the exit-code, way safer than checking output strings :P
 		return {}
 
-	print(o)		
+	if not o[:1] == b'{':
+		print('[E] Error in getting blk devices:', o)
+		exit(1)
+
 	r = json.loads(o.decode('UTF-8'))
 	if len(r['blockdevices']) and 'children' in r['blockdevices'][0]:
 		for part in r['blockdevices'][0]['children']:
@@ -460,8 +463,9 @@ if __name__ == '__main__':
 	# "--cipher sha512" breaks the shit.
 	# TODO: --use-random instead of --use-urandom
 	print('[N] Adding encryption to {drive}{partition_2}.'.format(**args))
-	o = sys_command('/usr/bin/cryptsetup -q -v --type luks2 --pbkdf argon2i --hash sha512 --key-size 512 --iter-time 10000 --key-file {pwfile} --use-urandom luksFormat {drive}{partition_2}'.format(**args)).exec()
-	if not 'Command successful.' in b''.join(o).decode('UTF-8').strip():
+	o = b''.join(sys_command('/usr/bin/cryptsetup -q -v --type luks2 --pbkdf argon2i --hash sha512 --key-size 512 --iter-time 10000 --key-file {pwfile} --use-urandom luksFormat {drive}{partition_2}'.format(**args)).exec())
+	print(o)
+	if not b'Command successful.' in o:
 		print('[E] Failed to setup disk encryption.', o)
 		exit(1)
 

--- a/archinstall.py
+++ b/archinstall.py
@@ -170,31 +170,30 @@ class sys_command():
 
 				yield output
 
-		x = os.waitpid(self.pid, 0)
-		print('Exited with:', x)
+		exit_code = os.waitpid(self.pid, 0)[1]
+		if exit_code != 0:
+			print('[E] Command "{}" exited with status code:'.format(self.cmd[0]), exit_code)
 
-# def sys_command(cmd, echo=False, opts=None, *args, **kwargs):
-# 	if not opts: opts = {}
-# 	if echo or 'debug' in opts:
-# 		print('[!] {}'.format(cmd))
-# 	handle = Popen(cmd, shell='True', stdout=PIPE, stderr=STDOUT, stdin=PIPE, **kwargs)
-# 	output = b''
-# 	while handle.poll() is None:
-# 		data = handle.stdout.read()
-# 		if b'or press Control-D' in data:
-# 			handle.stdin.write(b'')
-# 		if len(data):
-# 			if echo or 'debug' in opts:
-# 				print(data.decode('UTF-8'), end='')
-# 		#	print(data.decode('UTF-8'), end='')
-# 			output += data
-# 	data = handle.stdout.read()
-# 	if echo or 'debug' in opts:
-# 		print(data.decode('UTF-8'), end='')
-# 	output += data
-# 	handle.stdin.close()
-# 	handle.stdout.close()
-# 	return output
+def simple_command(cmd, opts=None, *args, **kwargs):
+	if not opts: opts = {}
+	if echo or 'debug' in opts:
+		print('[!] {}'.format(cmd))
+	handle = Popen(cmd, shell='True', stdout=PIPE, stderr=STDOUT, stdin=PIPE, **kwargs)
+	output = b''
+	while handle.poll() is None:
+		data = handle.stdout.read()
+		if len(data):
+			if echo or 'debug' in opts:
+				print(data.decode('UTF-8'), end='')
+		#	print(data.decode('UTF-8'), end='')
+			output += data
+	data = handle.stdout.read()
+	if echo or 'debug' in opts:
+		print(data.decode('UTF-8'), end='')
+	output += data
+	handle.stdin.close()
+	handle.stdout.close()
+	return output
 
 def update_git():
 	default_gw = get_default_gateway_linux()
@@ -204,7 +203,7 @@ def update_git():
 		os.remove('/root/archinstall/archinstall.py')
 		os.remove('/root/archinstall/README.md')
 
-		output = b''.join(sys_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2))').exec()) # git reset --hard origin/<branch_name> / git fetch --all
+		simple_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2))') # git reset --hard origin/<branch_name> / git fetch --all
 		print(output)
 
 		if b'error:' in output:

--- a/archinstall.py
+++ b/archinstall.py
@@ -236,7 +236,7 @@ def grab_partitions(dev):
 		## TODO: Replace o = sys_command() with code, o = sys_command()
 		##       and make sys_command() return the exit-code, way safer than checking output strings :P
 		return {}
-	r = json.loads(o)
+	r = json.loads(o.decode('UTF-8'))
 	if len(r['blockdevices']) and 'children' in r['blockdevices'][0]:
 		for part in r['blockdevices'][0]['children']:
 			parts[part['name'][len(drive_name):]] = {

--- a/archinstall.py
+++ b/archinstall.py
@@ -231,8 +231,8 @@ def device_state(name):
 def grab_partitions(dev):
 	drive_name = os.path.basename(dev)
 	parts = oDict()
-	o = sys_command('lsblk -o name -J -b {dev}'.format(dev=dev)).exec()
-	if b'not a block device' in b''.join(o):
+	o = b''.join(sys_command('lsblk -o name -J -b {dev}'.format(dev=dev)).exec())
+	if b'not a block device' in o:
 		## TODO: Replace o = sys_command() with code, o = sys_command()
 		##       and make sys_command() return the exit-code, way safer than checking output strings :P
 		return {}

--- a/archinstall.py
+++ b/archinstall.py
@@ -197,7 +197,7 @@ def update_git():
 		os.remove('/root/archinstall/archinstall.py')
 		os.remove('/root/archinstall/README.md')
 
-		output = sys_command('(cd /root/archinstall; git fetch --all)') # git reset --hard origin/<branch_name>
+		output = sys_command('(cd /root/archinstall; git fetch --all)').exec() # git reset --hard origin/<branch_name>
 		
 		if b'error:' in b''.join(output):
 			print('[N] Could not update git source for some reason.')
@@ -231,7 +231,7 @@ def device_state(name):
 def grab_partitions(dev):
 	drive_name = os.path.basename(dev)
 	parts = oDict()
-	o = sys_command('lsblk -o name -J -b {dev}'.format(dev=dev))
+	o = sys_command('lsblk -o name -J -b {dev}'.format(dev=dev)).exec()
 	if b'not a block device' in b''.join(o):
 		## TODO: Replace o = sys_command() with code, o = sys_command()
 		##       and make sys_command() return the exit-code, way safer than checking output strings :P

--- a/archinstall.py
+++ b/archinstall.py
@@ -176,19 +176,19 @@ class sys_command():
 
 def simple_command(cmd, opts=None, *args, **kwargs):
 	if not opts: opts = {}
-	if echo or 'debug' in opts:
+	if 'debug' in opts:
 		print('[!] {}'.format(cmd))
 	handle = Popen(cmd, shell='True', stdout=PIPE, stderr=STDOUT, stdin=PIPE, **kwargs)
 	output = b''
 	while handle.poll() is None:
 		data = handle.stdout.read()
 		if len(data):
-			if echo or 'debug' in opts:
+			if 'debug' in opts:
 				print(data.decode('UTF-8'), end='')
 		#	print(data.decode('UTF-8'), end='')
 			output += data
 	data = handle.stdout.read()
-	if echo or 'debug' in opts:
+	if 'debug' in opts:
 		print(data.decode('UTF-8'), end='')
 	output += data
 	handle.stdin.close()

--- a/archinstall.py
+++ b/archinstall.py
@@ -169,13 +169,18 @@ class sys_command():
 				if 'triggers' in self.opts:
 					for trigger in list(self.opts['triggers']):
 						if trigger.lower() in lower:
-							print('[N] Writing to subsystem: {}'.format(self.opts['triggers'][trigger]))
+							if 'debug' in self.opts and self.opts['debug']:
+								print('[N] Writing to subsystem: {}'.format(self.opts['triggers'][trigger]))
 							os.write(child_fd, self.opts['triggers'][trigger])
 							del(self.opts['triggers'][trigger])
 
 					## Adding a exit trigger:
 					if len(self.opts['triggers']) == 0:
+						if 'debug' in self.opts and self.opts['debug']:
+							print('[N] Waiting for last command to finish...')
 						if b'[root@arcinstall ~]#' in output:
+							if 'debug' in self.opts and self.opts['debug']:
+								print('[N] Last command finished, exiting subsystem.')
 							alive = False
 							break
 

--- a/archinstall.py
+++ b/archinstall.py
@@ -162,11 +162,13 @@ class sys_command():
 					break
 
 				if 'debug' in self.opts and self.opts['debug']:
-					print(output)
+					if len(output):
+						print(output)
 
 				lower = output.lower()
 				if 'triggers' in self.opts:
 					for trigger in self.opts['triggers']:
+						print(trigger.lower(),'vs', lower)
 						if trigger.lower() in lower:
 							os.write(child_fd, self.opts['triggers'][trigger])
 
@@ -639,7 +641,7 @@ if __name__ == '__main__':
 
 					## And then boot and execute:
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
-																												b'Archinstall login:' : b'root',
+																												b'Archinstall login' : b'root',
 																												b'Password' : bytes(args['password'], 'UTF-8'),
 																												b'root#' : bytes(command, 'UTF-8'),
 																											}, **opts}).exec())

--- a/archinstall.py
+++ b/archinstall.py
@@ -167,7 +167,7 @@ class sys_command():
 
 				lower = output.lower()
 				if 'triggers' in self.opts:
-					for trigger in self.opts['triggers']:
+					for trigger in list(self.opts['triggers']):
 						if trigger.lower() in lower:
 							print('[N] Writing to subsystem: {}'.format(self.opts['triggers'][trigger]))
 							os.write(child_fd, self.opts['triggers'][trigger])

--- a/archinstall.py
+++ b/archinstall.py
@@ -193,11 +193,12 @@ class sys_command():
 def update_git():
 	default_gw = get_default_gateway_linux()
 	if(default_gw):
+		print('[N] Updating git!')
 		## Not the most elegant way to make sure git conflicts doesn't occur (yea fml)
 		os.remove('/root/archinstall/archinstall.py')
 		os.remove('/root/archinstall/README.md')
 
-		output = b''.join(sys_command('(cd /root/archinstall; git fetch --all)').exec()) # git reset --hard origin/<branch_name>
+		output = b''.join(sys_command('(cd /root/archinstall; git update)').exec()) # git reset --hard origin/<branch_name>
 		
 		if b'error:' in output:
 			print('[N] Could not update git source for some reason.')
@@ -209,7 +210,8 @@ def update_git():
 			num_changes = int(tmp[0].split(b' ',1)[0])
 			if(num_changes):
 				## Reboot the script (in same context)
-				os.execv('/usr/bin/python3', ['archinstall.py', 'archinstall.py'] + sys.argv[1:])
+				print('[N] Rebooting the script')
+				os.execv('/usr/bin/python3', ['archinstall.py'] + sys.argv)
 
 def device_state(name):
 	# Based out of: https://askubuntu.com/questions/528690/how-to-get-list-of-all-non-removable-disk-device-names-ssd-hdd-and-sata-ide-onl/528709#528709
@@ -236,6 +238,8 @@ def grab_partitions(dev):
 		## TODO: Replace o = sys_command() with code, o = sys_command()
 		##       and make sys_command() return the exit-code, way safer than checking output strings :P
 		return {}
+
+	print(o)		
 	r = json.loads(o.decode('UTF-8'))
 	if len(r['blockdevices']) and 'children' in r['blockdevices'][0]:
 		for part in r['blockdevices'][0]['children']:

--- a/archinstall.py
+++ b/archinstall.py
@@ -170,7 +170,7 @@ class sys_command():
 					for trigger in self.opts['triggers']:
 						print(trigger.lower(),'vs', lower)
 						if trigger.lower() in lower:
-							print('[N] Writing to subsystem: {}'.format(trigger))
+							print('[N] Writing to subsystem: {}'.format(self.opts['triggers'][trigger]))
 							os.write(child_fd, self.opts['triggers'][trigger])
 
 				yield output
@@ -644,7 +644,7 @@ if __name__ == '__main__':
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
 																												b'Arcinstall login' : b'root\n',
 																												b'Password' : bytes(args['password']+'\n', 'UTF-8'),
-																												b'[root@Archinstall ~]#' : bytes(command+'\n', 'UTF-8'),
+																												b'[root@Arcinstall ~]#' : bytes(command+'\n', 'UTF-8'),
 																											}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..

--- a/archinstall.py
+++ b/archinstall.py
@@ -9,6 +9,10 @@ from collections import OrderedDict as oDict
 from subprocess import Popen, STDOUT, PIPE
 from time import sleep
 
+## == Profiles Path can be set via --profiles-path=/path
+##    This just sets the default path if the parameter is omitted.
+profiles_path = 'https://raw.githubusercontent.com/Torxed/archinstall/master/deployments'
+
 try:
 	import psutil
 except:
@@ -71,10 +75,6 @@ except:
 
 rootdir_pattern = re.compile('^.*?/devices')
 harddrives = oDict()
-
-## == Profiles Path can be set via --profiles-path=/path
-##    This just sets the default path if the parameter is omitted.
-profiles_path = 'https://raw.githubusercontent.com/Torxed/archinstall/master/deployments'
 
 args = {}
 positionals = []
@@ -202,7 +202,7 @@ def simple_command(cmd, opts=None, *args, **kwargs):
 def update_git():
 	default_gw = get_default_gateway_linux()
 	if(default_gw):
-		print('[N] Updating git!')
+		print('[N] Checking for updates...')
 		## Not the most elegant way to make sure git conflicts doesn't occur (yea fml)
 		if os.path.isfile('/root/archinstall/archinstall.py'):
 			os.remove('/root/archinstall/archinstall.py')
@@ -569,7 +569,7 @@ if __name__ == '__main__':
 	## For some reason, blkid and /dev/disk/by-uuid are not getting along well.
 	## And blkid is wrong in terms of LUKS.
 	#UUID = sys_command('blkid -s PARTUUID -o value {drive}{partition_2}'.format(**args)).decode('UTF-8').exec().strip()
-	UUID = b''.join(sys_command("/usr/bin/ls -l /dev/disk/by-uuid/ | grep {basename}{partition_2} | awk '{{print $9}}'".format(basename=os.path.basename(args['drive']), **args)).exec()).decode('UTF-8').strip()
+	UUID = simple_command("ls -l /dev/disk/by-uuid/ | grep {basename}{partition_2} | awk '{{print $9}}'".format(basename=os.path.basename(args['drive']), **args)).decode('UTF-8').strip()
 	with open('/mnt/boot/loader/entries/arch.conf', 'w') as entry:
 		entry.write('title Arch Linux\n')
 		entry.write('linux /vmlinuz-linux\n')

--- a/archinstall.py
+++ b/archinstall.py
@@ -178,7 +178,7 @@ class sys_command():
 					if len(self.opts['triggers']) == 0:
 						if 'debug' in self.opts and self.opts['debug']:
 							print('[N] Waiting for last command to finish...')
-						if b'[root@Archinstall ~]#' in output:
+						if bytes(f'[root@args["hostname"] ~]#'.lower(), 'UTF-8') in output.lower():
 							if 'debug' in self.opts and self.opts['debug']:
 								print('[N] Last command finished, exiting subsystem.')
 							alive = False
@@ -657,9 +657,9 @@ if __name__ == '__main__':
 
 					## And then boot and execute:
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
-																												b'Archinstall login' : b'root\n',
+																												bytes(f'{args["hostname"]} login', 'UTF-8') : b'root\n',
 																												b'Password' : bytes(args['password']+'\n', 'UTF-8'),
-																												b'[root@Archinstall ~]#' : bytes(command+'\n', 'UTF-8'),
+																												bytes(f'[root@args["hostname"] ~]#', 'UTF-8') : bytes(command+'\n', 'UTF-8'),
 																											}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..

--- a/archinstall.py
+++ b/archinstall.py
@@ -642,7 +642,7 @@ if __name__ == '__main__':
 
 					## And then boot and execute:
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
-																												b'Archinstall login' : b'root\n',
+																												b'Arcinstall login' : b'root\n',
 																												b'Password' : bytes(args['password']+'\n', 'UTF-8'),
 																												b'root#' : bytes(command+'\n', 'UTF-8'),
 																											}, **opts}).exec())

--- a/archinstall.py
+++ b/archinstall.py
@@ -205,7 +205,7 @@ def update_git():
 		if os.path.isfile('/root/archinstall/README.md'):
 			os.remove('/root/archinstall/README.md')
 
-		simple_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2))') # git reset --hard origin/<branch_name> / git fetch --all
+		output = simple_command('(cd /root/archinstall; git reset --hard origin/$(git branch | grep "*" | cut -d\' \' -f 2))') # git reset --hard origin/<branch_name> / git fetch --all
 		print(output)
 
 		if b'error:' in output:

--- a/archinstall.py
+++ b/archinstall.py
@@ -630,18 +630,18 @@ if __name__ == '__main__':
 					## So, if we're going to boot this maddafakker up, we'll need to
 					## be able to login. The quickest way is to just add automatic login.. so lessgo!
 					
-					if not os.path.isdir('/mnt/etc/systemd/system/console-getty.service.d/'):
-						os.makedirs('/mnt/etc/systemd/system/console-getty.service.d/')
-					with open('/mnt/etc/systemd/system/console-getty.service.d/override.conf', 'w') as fh:
-						fh.write('[Service]\n')
-						fh.write('ExecStart=\n')
-						fh.write('ExecStart=-/usr/bin/agetty --autologin root -s %I 115200,38400,9600 vt102\n')
+					# if not os.path.isdir('/mnt/etc/systemd/system/console-getty.service.d/'):
+					# 	os.makedirs('/mnt/etc/systemd/system/console-getty.service.d/')
+					# with open('/mnt/etc/systemd/system/console-getty.service.d/override.conf', 'w') as fh:
+					# 	fh.write('[Service]\n')
+					# 	fh.write('ExecStart=\n')
+					# 	fh.write('ExecStart=-/usr/bin/agetty --autologin root -s %I 115200,38400,9600 vt102\n')
 
 					## And then boot and execute:
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {b'Graphical Interface' : bytes(command, 'UTF-8')}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..
-					os.remove('/mnt/etc/systemd/system/console-getty.service.d/override.conf')
+					# os.remove('/mnt/etc/systemd/system/console-getty.service.d/override.conf')
 				else:
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt --machine temporary {c}'.format(c=command), opts=opts).exec())
 			if type(conf[title][raw_command]) == bytes and len(conf[title][raw_command]) and not conf[title][raw_command] in o:

--- a/archinstall.py
+++ b/archinstall.py
@@ -138,7 +138,7 @@ class sys_command():
 		if not self.cmd[0][0] == '/':
 			print('[N] Command is not executed with absolute path, trying to find it..')
 			o = b''.join(sys_command('/usr/bin/whereis {}'.format(self.cmd[0])).exec())
-			self.cmd[0] = o.split(b' ', 1)[0].decode('UTF-8')
+			self.cmd[0] = o.split(b' ')[1].decode('UTF-8')
 			print('[N] This is what I\'m going with: {}'.format(self.cmd[0]))
 		# PID = 0 for child, and the PID of the child for the parent    
 		self.pid, child_fd = pty.fork()
@@ -441,19 +441,19 @@ if __name__ == '__main__':
 	print('[N] Setting up {drive}.'.format(**args))
 	# dd if=/dev/random of=args['drive'] bs=4096 status=progress
 	# https://github.com/dcantrell/pyparted	would be nice, but isn't officially in the repo's #SadPanda
-	o = sys_command('/usr/bin/parted -s {drive} mklabel gpt'.format(**args)).exec()
-	o = sys_command('/usr/bin/parted -s {drive} mkpart primary FAT32 1MiB {start}'.format(**args)).exec()
-	o = sys_command('/usr/bin/parted -s {drive} name 1 "EFI"'.format(**args)).exec()
-	o = sys_command('/usr/bin/parted -s {drive} set 1 esp on'.format(**args)).exec()
-	o = sys_command('/usr/bin/parted -s {drive} set 1 boot on'.format(**args)).exec()
-	o = sys_command('/usr/bin/parted -s {drive} mkpart primary {start} {size}'.format(**args)).exec()
+	o = b''.join(sys_command('/usr/bin/parted -s {drive} mklabel gpt'.format(**args)).exec())
+	o = b''.join(sys_command('/usr/bin/parted -s {drive} mkpart primary FAT32 1MiB {start}'.format(**args)).exec())
+	o = b''.join(sys_command('/usr/bin/parted -s {drive} name 1 "EFI"'.format(**args)).exec())
+	o = b''.join(sys_command('/usr/bin/parted -s {drive} set 1 esp on'.format(**args)).exec())
+	o = b''.join(sys_command('/usr/bin/parted -s {drive} set 1 boot on'.format(**args)).exec())
+	o = b''.join(sys_command('/usr/bin/parted -s {drive} mkpart primary {start} {size}'.format(**args)).exec())
 	
 	args['paritions'] = grab_partitions(args['drive'])
 	if len(args['paritions']) <= 0:
 		print('[E] No paritions were created on {drive}'.format(**args), o)
 		exit(1)
 	for index, part_name in enumerate(args['paritions']):
-		args['partition_{}'.format(index+1)] = part_name
+ 		args['partition_{}'.format(index+1)] = part_name
 
 	o = b''.join(sys_command('/usr/bin/mkfs.vfat -F32 {drive}{partition_1}'.format(**args)).exec())
 	if (b'mkfs.fat' not in o and b'mkfs.vfat' not in o) or b'command not found' in o:
@@ -464,32 +464,31 @@ if __name__ == '__main__':
 	# TODO: --use-random instead of --use-urandom
 	print('[N] Adding encryption to {drive}{partition_2}.'.format(**args))
 	o = b''.join(sys_command('/usr/bin/cryptsetup -q -v --type luks2 --pbkdf argon2i --hash sha512 --key-size 512 --iter-time 10000 --key-file {pwfile} --use-urandom luksFormat {drive}{partition_2}'.format(**args)).exec())
-	print(o)
 	if not b'Command successful.' in o:
 		print('[E] Failed to setup disk encryption.', o)
 		exit(1)
 
-	o = sys_command('/usr/bin/cryptsetup open {drive}{partition_2} luksdev --key-file {pwfile} --type luks2'.format(**args)).exec()
+	o = b''.join(sys_command('/usr/bin/cryptsetup open {drive}{partition_2} luksdev --key-file {pwfile} --type luks2'.format(**args)).exec())
 	o = b''.join(sys_command('/usr/bin/file /dev/mapper/luksdev').exec()) # /dev/dm-0
 	if b'cannot open' in o:
 		print('[E] Could not mount encrypted device.', o)
 		exit(1)
 
 	print('[N] Creating btrfs filesystem inside {drive}{partition_2}'.format(**args))
-	o = sys_command('/usr/bin/mkfs.btrfs /dev/mapper/luksdev').exec()
-	if not b'UUID' in b''.join(o):
+	o = b''.join(sys_command('/usr/bin/mkfs.btrfs /dev/mapper/luksdev').exec())
+	if not b'UUID' in o:
 		print('[E] Could not setup btrfs filesystem.', o)
 		exit(1)
-	o = sys_command('/usr/bin/mount /dev/mapper/luksdev /mnt').exec()
+	o = b''.join(sys_command('/usr/bin/mount /dev/mapper/luksdev /mnt').exec())
 
 	os.makedirs('/mnt/boot')
-	o = sys_command('/usr/bin/mount {drive}{partition_1} /mnt/boot'.format(**args)).exec()
+	o = b''.join(sys_command('/usr/bin/mount {drive}{partition_1} /mnt/boot'.format(**args)).exec())
 
 	print('[N] Reordering mirrors.')
 	if 'mirrors' in args and args['mirrors'] and get_default_gateway_linux():
-		o = sys_command("/usr/bin/wget 'https://www.archlinux.org/mirrorlist/?country={country}&protocol=https&ip_version=4&ip_version=6&use_mirror_status=on' -O /root/mirrorlist".format(**args)).exec()
-		o = sys_command("/usr/bin/sed -i 's/#Server/Server/' /root/mirrorlist").exec()
-		o = sys_command('/usr/bin/rankmirrors -n 6 /root/mirrorlist > /etc/pacman.d/mirrorlist').exec()
+		o = b''.join(sys_command("/usr/bin/wget 'https://www.archlinux.org/mirrorlist/?country={country}&protocol=https&ip_version=4&ip_version=6&use_mirror_status=on' -O /root/mirrorlist".format(**args)).exec())
+		o = b''.join(sys_command("/usr/bin/sed -i 's/#Server/Server/' /root/mirrorlist").exec())
+		o = b''.join(sys_command('/usr/bin/rankmirrors -n 6 /root/mirrorlist > /etc/pacman.d/mirrorlist').exec())
 
 	pre_conf = {}
 	if 'pre' in instructions:
@@ -522,33 +521,33 @@ if __name__ == '__main__':
 					print('[-] Options: {}'.format(opts))
 
 			#print('[N] Command: {} ({})'.format(raw_command, opts))
-			o = sys_command('{c}'.format(c=command), opts).exec()
+			o = b''.join(sys_command('{c}'.format(c=command), opts).exec())
 			if type(conf[title][raw_command]) == bytes and len(conf[title][raw_command]) and not conf[title][raw_command] in b''.join(o):
 				print('[W] Prerequisit step failed: {}'.format(b''.join(o).decode('UTF-8')))
 			#print(o)
 
 	print('[N] Straping in packages.')
-	o = sys_command('/usr/bin/pacman -Syy').exec()
-	o = sys_command('/usr/bin/pacstrap /mnt base base-devel btrfs-progs efibootmgr nano wpa_supplicant dialog {packages}'.format(**args)).exec()
+	o = b''.join(sys_command('/usr/bin/pacman -Syy').exec())
+	o = b''.join(sys_command('/usr/bin/pacstrap /mnt base base-devel btrfs-progs efibootmgr nano wpa_supplicant dialog {packages}'.format(**args)).exec())
 
 	if not os.path.isdir('/mnt/etc'):
 		print('[E] Failed to strap in packages', o)
 		exit(1)
 
-	o = sys_command('/usr/bin/genfstab -pU /mnt >> /mnt/etc/fstab').exec()
+	o = b''.join(sys_command('/usr/bin/genfstab -pU /mnt >> /mnt/etc/fstab').exec())
 	with open('/mnt/etc/fstab', 'a') as fstab:
 		fstab.write('\ntmpfs /tmp tmpfs defaults,noatime,mode=1777 0 0\n') # Redundant \n at the start? who knoes?
 
-	o = sys_command('/usr/bin/arch-chroot /mnt rm /etc/localtime').exec()
-	o = sys_command('/usr/bin/arch-chroot /mnt ln -s /usr/share/zoneinfo/Europe/Stockholm /etc/localtime').exec()
-	o = sys_command('/usr/bin/arch-chroot /mnt hwclock --hctosys --localtime').exec()
+	o = b''.join(sys_command('/usr/bin/arch-chroot /mnt rm /etc/localtime').exec())
+	o = b''.join(sys_command('/usr/bin/arch-chroot /mnt ln -s /usr/share/zoneinfo/Europe/Stockholm /etc/localtime').exec())
+	o = b''.join(sys_command('/usr/bin/arch-chroot /mnt hwclock --hctosys --localtime').exec())
 	#o = sys_command('arch-chroot /mnt echo "{hostname}" > /etc/hostname'.format(**args)).exec()
 	#o = sys_command("arch-chroot /mnt sed -i 's/#\(en_US\.UTF-8\)/\1/' /etc/locale.gen").exec()
-	o = sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo '{hostname}' > /etc/hostname\"".format(**args)).exec()
-	o = sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen\"").exec()
-	o = sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo 'LANG=en_US.UTF-8' > /etc/locale.conf\"").exec()
-	o = sys_command('/usr/bin/arch-chroot /mnt locale-gen').exec()
-	o = sys_command('/usr/bin/arch-chroot /mnt chmod 700 /root').exec()
+	o = b''.join(sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo '{hostname}' > /etc/hostname\"".format(**args)).exec())
+	o = b''.join(sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen\"").exec())
+	o = b''.join(sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo 'LANG=en_US.UTF-8' > /etc/locale.conf\"").exec())
+	o = b''.join(sys_command('/usr/bin/arch-chroot /mnt locale-gen').exec())
+	o = b''.join(sys_command('/usr/bin/arch-chroot /mnt chmod 700 /root').exec())
 
 	with open('/mnt/etc/mkinitcpio.conf', 'w') as mkinit:
 		## TODO: Don't replace it, in case some update in the future actually adds something.
@@ -556,8 +555,8 @@ if __name__ == '__main__':
 		mkinit.write('BINARIES=(/usr/bin/btrfs)\n')
 		mkinit.write('FILES=()\n')
 		mkinit.write('HOOKS=(base udev autodetect modconf block encrypt filesystems keyboard fsck)\n')
-	o = sys_command('/usr/bin/arch-chroot /mnt mkinitcpio -p linux').exec()
-	o = sys_command('/usr/bin/arch-chroot /mnt bootctl --path=/boot install').exec()
+	o = b''.join(sys_command('/usr/bin/arch-chroot /mnt mkinitcpio -p linux').exec())
+	o = b''.join(sys_command('/usr/bin/arch-chroot /mnt bootctl --path=/boot install').exec())
 
 	with open('/mnt/boot/loader/loader.conf', 'w') as loader:
 		loader.write('default arch\n')
@@ -608,25 +607,25 @@ if __name__ == '__main__':
 			## Either skipping mounting /run and using traditional chroot is an option, but using
 			## `systemd-nspawn -D /mnt --machine temporary` might be a more flexible solution in case of file structure changes.
 			if 'no-chroot' in opts and opts['no-chroot']:
-				o = sys_command(command, opts).exec()
+				o = b''.join(sys_command(command, opts).exec())
 			elif 'chroot' in opts and opts['chroot']:
 				## Run in a manually set up version of arch-chroot (arch-chroot will break namespaces).
 				## This is a bit risky in case the file systems changes over the years, but we'll probably be safe adding this as an option.
 				## **> Prefer if possible to use 'no-chroot' instead which "live boots" the OS and runs the command.
-				o = sys_command("/usr/bin/mount /dev/mapper/luksdev /mnt").exec()
-				o = sys_command("cd /mnt; cp /etc/resolv.conf etc").exec()
-				o = sys_command("cd /mnt; /usr/bin/mount -t proc /proc proc").exec()
-				o = sys_command("cd /mnt; /usr/bin/mount --make-rslave --rbind /sys sys").exec()
-				o = sys_command("cd /mnt; /usr/bin/mount --make-rslave --rbind /dev dev").exec()
-				o = sys_command('/usr/bin/chroot /mnt /bin/bash -c "{c}"'.format(c=command), opts=opts).exec()
-				o = sys_command("cd /mnt; /usr/bin/umount -R dev").exec()
-				o = sys_command("cd /mnt; /usr/bin/umount -R sys").exec()
-				o = sys_command("cd /mnt; /usr/bin/umount -R proc").exec()
+				o = b''.join(sys_command("/usr/bin/mount /dev/mapper/luksdev /mnt").exec())
+				o = b''.join(sys_command("cd /mnt; cp /etc/resolv.conf etc").exec())
+				o = b''.join(sys_command("cd /mnt; /usr/bin/mount -t proc /proc proc").exec())
+				o = b''.join(sys_command("cd /mnt; /usr/bin/mount --make-rslave --rbind /sys sys").exec())
+				o = b''.join(sys_command("cd /mnt; /usr/bin/mount --make-rslave --rbind /dev dev").exec())
+				o = b''.join(sys_command('/usr/bin/chroot /mnt /bin/bash -c "{c}"'.format(c=command), opts=opts).exec())
+				o = b''.join(sys_command("cd /mnt; /usr/bin/umount -R dev").exec())
+				o = b''.join(sys_command("cd /mnt; /usr/bin/umount -R sys").exec())
+				o = b''.join(sys_command("cd /mnt; /usr/bin/umount -R proc").exec())
 			else:
 				if 'boot' in opts and opts['boot']:
-					o = sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary {c}'.format(c=command), opts=opts).exec()
+					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary {c}'.format(c=command), opts=opts).exec())
 				else:
-					o = sys_command('/usr/bin/systemd-nspawn -D /mnt --machine temporary {c}'.format(c=command), opts=opts).exec()
+					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt --machine temporary {c}'.format(c=command), opts=opts).exec())
 			if type(conf[title][raw_command]) == bytes and len(conf[title][raw_command]) and not conf[title][raw_command] in o:
 				print('[W] Post install command failed: {}'.format(o.decode('UTF-8')))
 			#print(o)
@@ -634,13 +633,13 @@ if __name__ == '__main__':
 	## == Passwords
 	# o = sys_command('arch-chroot /mnt usermod --password {} root'.format(args['password']))
 	# o = sys_command("arch-chroot /mnt sh -c 'echo {pin} | passwd --stdin root'".format(pin='"{pin}"'.format(**args, pin=args['password'])), echo=True)
-	o = sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo 'root:{pin}' | chpasswd\"".format(**args, pin=args['password'])).exec()
+	o = b''.join(sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo 'root:{pin}' | chpasswd\"".format(**args, pin=args['password'])).exec())
 	if 'user' in args:
-		o = sys_command('/usr/bin/arch-chroot /mnt useradd -m -G wheel {user}'.format(**args)).exec()
-		o = sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo '{user}:{pin}' | chpasswd\"".format(**args, pin=args['password'])).exec()
+		o = b''.join(sys_command('/usr/bin/arch-chroot /mnt useradd -m -G wheel {user}'.format(**args)).exec())
+		o = b''.join(sys_command("/usr/bin/arch-chroot /mnt sh -c \"echo '{user}:{pin}' | chpasswd\"".format(**args, pin=args['password'])).exec())
 
 	if args['post'] == 'reboot':
-		o = sys_command('/usr/bin/umount -R /mnt').exec()
-		o = sys_command('/usr/bin/reboot now').exec()
+		o = b''.join(sys_command('/usr/bin/umount -R /mnt').exec())
+		o = b''.join(sys_command('/usr/bin/reboot now').exec())
 	else:
 		print('Done. "umount -R /mnt; reboot" when you\'re done tinkering.')

--- a/archinstall.py
+++ b/archinstall.py
@@ -178,7 +178,7 @@ class sys_command():
 					if len(self.opts['triggers']) == 0:
 						if 'debug' in self.opts and self.opts['debug']:
 							print('[N] Waiting for last command to finish...')
-						if b'[root@arcinstall ~]#' in output:
+						if b'[root@Archinstall ~]#' in output:
 							if 'debug' in self.opts and self.opts['debug']:
 								print('[N] Last command finished, exiting subsystem.')
 							alive = False
@@ -359,7 +359,7 @@ if __name__ == '__main__':
 	if not 'size' in args: args['size'] = '100%'
 	if not 'start' in args: args['start'] = '513MiB'
 	if not 'pwfile' in args: args['pwfile'] = '/tmp/diskpw'
-	if not 'hostname' in args: args['hostname'] = 'Arcinstall'
+	if not 'hostname' in args: args['hostname'] = 'Archinstall'
 	if not 'country' in args: args['country'] = 'SE' # 'all' if we don't want country specific mirrors.
 	if not 'packages' in args: args['packages'] = '' # extra packages other than default
 	if not 'post' in args: args['post'] = 'reboot'
@@ -657,9 +657,9 @@ if __name__ == '__main__':
 
 					## And then boot and execute:
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
-																												b'Arcinstall login' : b'root\n',
+																												b'Archinstall login' : b'root\n',
 																												b'Password' : bytes(args['password']+'\n', 'UTF-8'),
-																												b'[root@Arcinstall ~]#' : bytes(command+'\n', 'UTF-8'),
+																												b'[root@Archinstall ~]#' : bytes(command+'\n', 'UTF-8'),
 																											}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..

--- a/archinstall.py
+++ b/archinstall.py
@@ -168,6 +168,7 @@ class sys_command():
 				lower = output.lower()
 				if 'triggers' in self.opts:
 					for trigger in list(self.opts['triggers']):
+						print(trigger.lower(), 'vs', lower)
 						if trigger.lower() in lower:
 							if 'debug' in self.opts and self.opts['debug']:
 								print('[N] Writing to subsystem: {}'.format(self.opts['triggers'][trigger]))

--- a/archinstall.py
+++ b/archinstall.py
@@ -179,7 +179,7 @@ class sys_command():
 					if len(self.opts['triggers']) == 0:
 						if 'debug' in self.opts and self.opts['debug']:
 							print('[N] Waiting for last command to finish...')
-						if bytes(f'[root@args["hostname"] ~]#'.lower(), 'UTF-8') in output.lower():
+						if bytes(f'[root@{args["hostname"]} ~]#'.lower(), 'UTF-8') in output.lower():
 							if 'debug' in self.opts and self.opts['debug']:
 								print('[N] Last command finished, exiting subsystem.')
 							alive = False
@@ -660,7 +660,7 @@ if __name__ == '__main__':
 					o = b''.join(sys_command('/usr/bin/systemd-nspawn -D /mnt -b --machine temporary', opts={'triggers' : {
 																												bytes(f'{args["hostname"]} login', 'UTF-8') : b'root\n',
 																												b'Password' : bytes(args['password']+'\n', 'UTF-8'),
-																												bytes(f'[root@args["hostname"] ~]#', 'UTF-8') : bytes(command+'\n', 'UTF-8'),
+																												bytes(f'[root@{args["hostname"]} ~]#', 'UTF-8') : bytes(command+'\n', 'UTF-8'),
 																											}, **opts}).exec())
 
 					## And cleanup after out selves.. Don't want to leave any residue..


### PR DESCRIPTION
 * Uses `systemd-nspawn` to pseudo-boot the installed OS for more elaborate installation steps
 * Added triggers that can be used to react to certain things in the booted subsystem
 * Almost all previous `run()` commands now use `sys_command()` in case future changes requires integration
 * `sys_command` can also interact with protected tty integrations, such as `ssh` password requests.
 * Added a lot more debug information and some smaller error handlers
 * Fixed the git self-updated to actually work.. Haven't done in a while.