### PR TITLE
Fixed #14, #9 - No more accidental disk eating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # archinstall
-Just a bare bone automated [Arch](https://wiki.archlinux.org/index.php/Arch_Linux) install with network deployment instructions based on MAC-address.
+Just a bare bone automated [Arch](https://wiki.archlinux.org/index.php/Arch_Linux) install with optional network deployment instructions based on MAC-address.
 
 Pre-built ISO's can be found here: https://hvornum.se/archiso/
 
@@ -7,13 +7,12 @@ Pre-built ISO's can be found here: https://hvornum.se/archiso/
 In a live-cd environment, do:
 
     # wget https://raw.githubusercontent.com/Torxed/archinstall/master/archinstall.py
-    # python3 archinstall.py --default
+    # pacman -S --noconfirm python; python archinstall.py --default
 
-> **CAUTION**: If no **other** parameters are given, **it will devour the first disk in your system** (Usually `/dev/sda`, `/dev/nvme0n1` etc).
+This will install a basic Arch Linux, without interaction, on the first drive it finds *(after user confirms it)*.<br>
+Use `--drive=/dev/sdb` etc to change the desired destination, or skip `--default` if you want to get options for your installation.
 
-This will install a basic Arch Linux, without interaction, on the first drive it finds. Use `--drive=/dev/sdb` etc to change the desired destination, or skip `--default` if you want to get options for your installation.
-
-> NOTE: This assumes Python is installed on your ISO, follow [ArchISO](https://wiki.archlinux.org/index.php/archiso)'s guide on how to create your own ISO or use a pre-built [guided ISO](https://hvornum.se/archiso/). Below is examples and a cheat sheet on how to create such a ISO *(with different flavors)*.
+> NOTE: Follow [ArchISO](https://wiki.archlinux.org/index.php/archiso)'s guide on how to create your own ISO or use a pre-built [guided ISO](https://hvornum.se/archiso/) to skip the python installation step, or to create auto-installing ISO templates. Below is examples and a cheat sheet on how to create such a ISO *(with different flavors)*.
 
 # Features
 

--- a/archinstall.py
+++ b/archinstall.py
@@ -482,7 +482,7 @@ if __name__ == '__main__':
 	if not 'localtime' in args: args['localtime'] = 'Europe/Stockholm' if args['country'] == 'SE' else 'GMT+0' # TODO: Arbitrary for now
 	if not 'drive' in args:
 		drives = list(harddrives.keys())
-		if len(drives) > 1 and not ('force' in args or 'first-drive' in args or 'default' in args):
+		if len(drives) > 1 and 'force' not in args and ('default' in args and 'first-drive' not in args):
 			raise KeyError("Multiple disks found, --drive=/dev/X not specified (or --force/--first-drive)")
 		args['drive'] = sorted(drives)[0] # First drive found
 	rerun = args['ignore-rerun']
@@ -587,7 +587,7 @@ if __name__ == '__main__':
 	print(json.dumps(args, indent=4))
 	if args['default'] and not 'force' in args:
 		if(input('Are these settings OK? (No return beyond this point) N/y: ').lower() != 'y'):
-			die(1)
+			exit(1)
 
 	if not os.path.isfile(args['pwfile']):
 		#PIN = '0000'

--- a/archinstall.py
+++ b/archinstall.py
@@ -466,7 +466,6 @@ if __name__ == '__main__':
 		exit(1)
 
 	## Setup some defaults (in case no command-line parameters or netdeploy-params were given)
-	if not 'drive' in args: args['drive'] = sorted(list(harddrives.keys()))[0] # First drive found
 	if not 'size' in args: args['size'] = '100%'
 	if not 'start' in args: args['start'] = '513MiB'
 	if not 'pwfile' in args: args['pwfile'] = '/tmp/diskpw'
@@ -480,6 +479,12 @@ if __name__ == '__main__':
 	if not 'profiles-path' in args: args['profiles-path'] = profiles_path
 	if not 'rerun' in args: args['rerun'] = None
 	if not 'ignore-rerun' in args: args['ignore-rerun'] = False
+	if not 'localtime' in args: args['localtime'] = 'Europe/Stockholm' if args['country'] == 'SE' else 'GMT+0' # TODO: Arbitrary for now
+	if not 'drive' in args:
+		drives = list(harddrives.keys())
+		if len(drives) > 1 and not ('force' in args or 'first-drive' in args):
+			raise KeyError("Multiple disks found, and --force / --first-drive wasn't specified.")
+		args['drive'] = sorted(drives)[0] # First drive found
 	rerun = args['ignore-rerun']
 
 	if args['drive'][0] != '/':
@@ -722,7 +727,7 @@ if __name__ == '__main__':
 			fstab.write('\ntmpfs /tmp tmpfs defaults,noatime,mode=1777 0 0\n') # Redundant \n at the start? who knoes?
 
 		o = b''.join(sys_command('/usr/bin/arch-chroot /mnt rm /etc/localtime').exec())
-		o = b''.join(sys_command('/usr/bin/arch-chroot /mnt ln -s /usr/share/zoneinfo/Europe/Stockholm /etc/localtime').exec())
+		o = b''.join(sys_command('/usr/bin/arch-chroot /mnt ln -s /usr/share/zoneinfo/{localtime} /etc/localtime'.format(**args)).exec())
 		o = b''.join(sys_command('/usr/bin/arch-chroot /mnt hwclock --hctosys --localtime').exec())
 		#o = sys_command('arch-chroot /mnt echo "{hostname}" > /etc/hostname'.format(**args)).exec()
 		#o = sys_command("arch-chroot /mnt sed -i 's/#\(en_US\.UTF-8\)/\1/' /etc/locale.gen").exec()

--- a/archinstall.py
+++ b/archinstall.py
@@ -482,8 +482,8 @@ if __name__ == '__main__':
 	if not 'localtime' in args: args['localtime'] = 'Europe/Stockholm' if args['country'] == 'SE' else 'GMT+0' # TODO: Arbitrary for now
 	if not 'drive' in args:
 		drives = list(harddrives.keys())
-		if len(drives) > 1 and not ('force' in args or 'first-drive' in args):
-			raise KeyError("Multiple disks found, and --force / --first-drive wasn't specified.")
+		if len(drives) > 1 and not ('force' in args or 'first-drive' in args or 'default' in args):
+			raise KeyError("Multiple disks found, --drive=/dev/X not specified (or --force/--first-drive)")
 		args['drive'] = sorted(drives)[0] # First drive found
 	rerun = args['ignore-rerun']
 
@@ -585,6 +585,9 @@ if __name__ == '__main__':
 #		if not args['password']:
 
 	print(json.dumps(args, indent=4))
+	if args['default'] and not 'force' in args:
+		if(input('Are these settings OK? (No return beyond this point) N/y: ').lower() != 'y'):
+			die(1)
 
 	if not os.path.isfile(args['pwfile']):
 		#PIN = '0000'


### PR DESCRIPTION
* Unless template specifies and --force / --default is used, there is now a confirmation step after the settings are printed to the user
 * If multiple disks are found, the first isn't automatically selected unless `--first-drive` is supplied (or `--force`).