### PR TITLE
Added a configuration overview before formatting

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -25,6 +25,16 @@ class BlockDevice():
 			raise KeyError(f'{self} does not contain information: "{key}"')
 		return self.info[key]
 
+	def json(self):
+		"""
+		json() has precedence over __dump__, so this is a way
+		to give less/partial information for user readability.
+		"""
+		return {
+			'path' : self.path,
+			'size' : self.info['size'] if 'size' in self.info else '<unknown>'
+		}
+
 	def __dump__(self):
 		return {
 			'path' : self.path,

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -31,9 +31,6 @@ def locate_binary(name):
 					return os.path.join(root, file)
 			break # Don't recurse
 
-def to_json(dictionary):
-	return json.dumps(dictionary, cls=)
-
 class JSON_Encoder:
 	def _encode(obj):
 		if isinstance(obj, dict):

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -1,6 +1,6 @@
 import os, json, hashlib, shlex, sys
 import time, pty
-from datetime import datetime
+from datetime import datetime, date
 from subprocess import Popen, STDOUT, PIPE, check_output
 from select import epoll, EPOLLIN, EPOLLHUP
 from .exceptions import *

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -1,5 +1,6 @@
 import os, json, hashlib, shlex, sys
 import time, pty
+from datetime import datetime
 from subprocess import Popen, STDOUT, PIPE, check_output
 from select import epoll, EPOLLIN, EPOLLHUP
 from .exceptions import *
@@ -29,6 +30,46 @@ def locate_binary(name):
 				if file == name:
 					return os.path.join(root, file)
 			break # Don't recurse
+
+def to_json(dictionary):
+	return json.dumps(dictionary, cls=)
+
+class JSON_Encoder:
+	def _encode(obj):
+		if isinstance(obj, dict):
+			## We'll need to iterate not just the value that default() usually gets passed
+			## But also iterate manually over each key: value pair in order to trap the keys.
+			
+			for key, val in list(obj.items()):
+				if isinstance(val, dict):
+					val = json.loads(json.dumps(val, cls=JSON)) # This, is a EXTREMELY ugly hack..
+                                                            # But it's the only quick way I can think of to 
+                                                            # trigger a encoding of sub-dictionaries.
+				else:
+					val = JSON_Encoder._encode(val)
+				del(obj[key])
+				obj[JSON_Encoder._encode(key)] = val
+			return obj
+		elif hasattr(obj, 'json'):
+			return obj.json()
+		elif hasattr(obj, '__dump__'):
+			return obj.__dump__()
+		elif isinstance(obj, (datetime, date)):
+			return obj.isoformat()
+		elif isinstance(obj, (list, set, tuple)):
+			r = []
+			for item in obj:
+				r.append(json.loads(json.dumps(item, cls=JSON)))
+			return r
+		else:
+			return obj
+
+class JSON(json.JSONEncoder, json.JSONDecoder):
+	def _encode(self, obj):
+		return JSON_Encoder._encode(obj)
+
+	def encode(self, obj):
+		return super(JSON, self).encode(self._encode(obj))
 
 class sys_command():#Thread):
 	"""

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -61,6 +61,9 @@ class Profile():
 		self._cache = None
 		self.args = args
 
+	def __dump__(self, *args, **kwargs):
+		return {'path' : self._path}
+
 	def __repr__(self, *args, **kwargs):
 		return f'Profile({self._path} <"{self.path}">)'
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -137,7 +137,7 @@ while 1:
 	except archinstall.RequirementError as e:
 		print(e)
 
-print(json.dumps(archinstall.storage['_guided'], indent=4, sort_keys=True))
+print(json.dumps(archinstall.storage['_guided'], indent=4, sort_keys=True, cls=archinstall.JSON))
 
 """
 	Issue a final warning before we continue with something un-revertable.

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -1,6 +1,5 @@
 import archinstall
 import getpass, time, json, sys, signal
-from select import epoll, EPOLLIN
 
 """
 This signal-handler chain (and global variable)
@@ -166,8 +165,6 @@ print()
 
 print(f' ! Formatting {harddrive} in ', end='')
 
-poller = epoll()
-poller.register(sys.stdin.fileno(), EPOLLIN)
 for i in range(5, 0, -1):
 	print(f"{i}", end='')
 
@@ -176,7 +173,7 @@ for i in range(5, 0, -1):
 		time.sleep(0.25)
 		print(".", end='')
 
-	if list(poller.poll(0.25)) or SIG_TRIGGER:
+	if SIG_TRIGGER:
 		abort = input('\nDo you really want to abort (y/n)? ')
 		if abort.strip() != 'n':
 			exit(0)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -115,6 +115,7 @@ while 1:
 		archinstall.storage['_guided']['profile'] = profile
 
 		if type(profile) != str: # Got a imported profile
+			archinstall.storage['_guided']['profile'] = profile[0] # The second return is a module, and not a handle/object.
 			if not profile[1]._prep_function():
 				archinstall.log(' * Profile\'s preperation requirements was not fulfilled.', bg='black', fg='red')
 				continue

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -139,7 +139,10 @@ while 1:
 	except archinstall.RequirementError as e:
 		print(e)
 
+print()
+print('This is your chosen configuration:')
 print(json.dumps(archinstall.storage['_guided'], indent=4, sort_keys=True, cls=archinstall.JSON))
+print()
 
 """
 	Issue a final warning before we continue with something un-revertable.

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -1,4 +1,5 @@
-import archinstall, getpass, time, json
+import archinstall
+import getpass, time, json, sys
 
 def perform_installation(device, boot_partition, language, mirrors):
 	"""

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -13,6 +13,7 @@ def sig_handler(sig, frame):
 	global SIG_TRIGGER
 	SIG_TRIGGER = True
 	signal.signal(signal.SIGINT, kill_handler)
+original_sigint_handler = signal.getsignal(signal.SIGINT)
 signal.signal(signal.SIGINT, sig_handler)
 
 def perform_installation(device, boot_partition, language, mirrors):
@@ -183,7 +184,7 @@ for i in range(5, 0, -1):
 		SIG_TRIGGER = False
 		signal.signal(signal.SIGINT, sig_handler)
 print()
-signal.signal(signal.SIGINT, kill_handler)
+signal.signal(signal.SIGINT, original_sigint_handler)
 
 """
 	Setup the blockdevice, filesystem (and optionally encryption).

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -183,6 +183,8 @@ for i in range(5, 0, -1):
 		SIG_TRIGGER = False
 		signal.signal(signal.SIGINT, sig_handler)
 print()
+signal.signal(signal.SIGINT, kill_handler)
+
 """
 	Setup the blockdevice, filesystem (and optionally encryption).
 	Once that's done, we'll hand over to perform_installation()


### PR DESCRIPTION
## Description

Implemented a quick `json.dumps()` output for the current setting. It's being echoed right before the warning of disk formatting. The disk formatting also got a tweak so that you can press <kbd>Ctrl+C</kbd> in order to pause the formatting-warning in order to read the config.

## Bugs and Issues

This should fix #43 

## How Has This Been Tested?

**Test Configuration**:
* Hardware: qemu (KVM) 5.1.0-1
* Specific steps: Ran the installer and <kbd>Ctrl+C</kbd> when the "Formatting in ..." started

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
