### PR TITLE
Shell script calling python & support for specifying remote profiles and full paths

### DIFF
--- a/PKGBUILD/archinstall/PKGBUILD
+++ b/PKGBUILD/archinstall/PKGBUILD
@@ -1,5 +1,5 @@
-# Maintainer: Anton Hvornum anton@hvornum.se
-# Contributor: Anton Hvornum anton@hvornum.se
+# Maintainer: Anton Hvornum <anton@hvornum.se>
+# Contributor: demostanis worlds <demostanis@protonmail.com>
 pkgname="archinstall"
 pkgver="2.0.5"
 pkgdesc="Installs launcher scripts for archinstall"
@@ -24,3 +24,6 @@ EOF
 
 	chmod +x "${pkgdir}/usr/bin/archinstall"
 }
+
+# vim:ft=sh
+

--- a/PKGBUILD/archinstall/PKGBUILD
+++ b/PKGBUILD/archinstall/PKGBUILD
@@ -7,27 +7,20 @@ pkgrel=1
 url="https://github.com/Torxed/archinstall"
 license=('GPLv3')
 provides=("${pkgname}")
-md5sums=('SKIP')
 arch=('x86_64')
 source=("${pkgname}-v${pkgver}-x86_64.tar.gz::https://github.com/Torxed/archinstall/archive/v$pkgver.tar.gz")
 depends=('python-archinstall')
+md5sums=('a23ec87d901d9dc28a8a36dd7427200f')
  
 package() {
 	mkdir -p "${pkgdir}/usr/bin"
 
 	# Install a guided profile
-	echo '#!/bin/bash' > "${pkgdir}/usr/bin/archinstall-guided"
-	echo 'python -m archinstall guided' >> "${pkgdir}/usr/bin/archinstall-guided"
+	cat - > "${pkgdir}/usr/bin/archinstall" <<EOF
+#!/bin/sh
 
-	# Install a minimal profile
-	echo '#!/bin/bash' > "${pkgdir}/usr/bin/archinstall-minimal"
-	echo 'python -m archinstall minimal' >> "${pkgdir}/usr/bin/archinstall-minimal"
+python -m archinstall $@
+EOF
 
-	# Install a unattended profile (safely aborts if no machine specific instructions are found)
-	#echo '#!/bin/bash' > "${pkgdir}/usr/bin/archinstall-unattended"
-	#echo 'python -m archinstall unattended' >> "${pkgdir}/usr/bin/archinstall-unattended"
-
-	chmod +x "${pkgdir}/usr/bin/archinstall-guided"
-	chmod +x "${pkgdir}/usr/bin/archinstall-minimal"
-	#chmod +x "${pkgdir}/usr/bin/archinstall-unattended"
+	chmod +x "${pkgdir}/usr/bin/archinstall"
 }

--- a/PKGBUILD/archinstall/PKGBUILD
+++ b/PKGBUILD/archinstall/PKGBUILD
@@ -10,7 +10,7 @@ provides=("${pkgname}")
 arch=('x86_64')
 source=("${pkgname}-v${pkgver}-x86_64.tar.gz::https://github.com/Torxed/archinstall/archive/v$pkgver.tar.gz")
 depends=('python-archinstall')
-md5sums=('a23ec87d901d9dc28a8a36dd7427200f')
+sha256sums=('04176c096d13589b874083aecbb9b1d34e676d2b784f55e5368f4ab83ff38c2e')
  
 package() {
 	mkdir -p "${pkgdir}/usr/bin"

--- a/PKGBUILD/python-archinstall/PKGBUILD
+++ b/PKGBUILD/python-archinstall/PKGBUILD
@@ -1,26 +1,34 @@
-# Maintainer: Anton Hvornum anton@hvornum.se
-# Contributor: Anton Hvornum anton@hvornum.se
+# Maintainer: Anton Hvornum <anton@hvornum.se>
+# Contributor: demostanis worlds <demostanis@protonmail.com>
+
 pkgname="python-archinstall"
 pkgver="2.0.5"
 pkgdesc="Installs ${pkgname} as a python library."
 pkgrel=1
 url="https://github.com/Torxed/archinstall"
+source=("${pkgname}-v${pkgver}-x86_64.tar.gz::https://github.com/Torxed/archinstall/archive/v$pkgver.tar.gz")
 license=('GPLv3')
 provides=("${pkgname}")
-md5sums=('SKIP')
 arch=('x86_64')
-source=("${pkgname}-v${pkgver}-x86_64.tar.gz::https://github.com/Torxed/archinstall/archive/v$pkgver.tar.gz")
 depends=('python>=3.8')
-optdepends=('pyttsx3: Adds text-to-speach support for log/screen output.')
+makedepends=('python-setuptools')
+optdepends=('pyttsx3: Adds text-to-speech support for log/screen output.')
+md5sums=('a23ec87d901d9dc28a8a36dd7427200f')
 
 build() {
 	cd "archinstall-${pkgver}"
 
-	python3 setup.py build
+	python setup.py build
 }
  
 package() {
 	cd "archinstall-${pkgver}"
 
-	python setup.py install --prefix=/usr --root="${pkgdir}" --optimize=1
+	python setup.py install \
+		--prefix=/usr \
+		--root="${pkgdir}" \
+		--optimize=1
 }
+
+# vim:ft=sh
+

--- a/PKGBUILD/python-archinstall/PKGBUILD
+++ b/PKGBUILD/python-archinstall/PKGBUILD
@@ -13,7 +13,7 @@ arch=('x86_64')
 depends=('python>=3.8')
 makedepends=('python-setuptools')
 optdepends=('pyttsx3: Adds text-to-speech support for log/screen output.')
-md5sums=('a23ec87d901d9dc28a8a36dd7427200f')
+sha256sums=('04176c096d13589b874083aecbb9b1d34e676d2b784f55e5368f4ab83ff38c2e')
 
 build() {
 	cd "archinstall-${pkgver}"

--- a/archinstall/__main__.py
+++ b/archinstall/__main__.py
@@ -6,63 +6,63 @@ import glob
 import urllib.request
 
 # TODO: Learn the dark arts of argparse...
-#       (I summon thee dark spawn of cPython)
+#	   (I summon thee dark spawn of cPython)
 
 
 class ProfileNotFound(BaseException):
-    pass
+	pass
 
 
 def find_examples():
-    """
-    Used to locate the examples, bundled with the module or executable.
+	"""
+	Used to locate the examples, bundled with the module or executable.
 
-    :return: {'guided.py' : './examples/guided.py', '<profile #2>' : '<path #2>'}
-    :rtype: dict
-    """
-    cwd = os.path.abspath(f'{os.path.dirname(__file__)}')
-    examples = f"{cwd}/examples"
+	:return: {'guided.py' : './examples/guided.py', '<profile #2>' : '<path #2>'}
+	:rtype: dict
+	"""
+	cwd = os.path.abspath(f'{os.path.dirname(__file__)}')
+	examples = f"{cwd}/examples"
 
-    return {os.path.basename(path): path for path in glob.glob(f'{examples}/*.py')}
+	return {os.path.basename(path): path for path in glob.glob(f'{examples}/*.py')}
 
 
 def find(url):
-    parsed_url = urlparse(url)
-    if not parsed_url.scheme:
-        examples = find_examples()
-        if f"{url}.py" in examples:
-            return open(examples[f"{url}.py"]).read()
-        try:
-            return open(url, 'r').read()
-        except FileNotFoundError:
-            return ProfileNotFound(f"File {url} does not exist")
-    elif parsed_url.scheme in ('https', 'http'):
-        return urllib.request.urlopen(url).read().decode('utf-8')
-    else:
-        return ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
+	parsed_url = urlparse(url)
+	if not parsed_url.scheme:
+	    examples = find_examples()
+	    if f"{url}.py" in examples:
+	        return open(examples[f"{url}.py"]).read()
+	    try:
+	        return open(url, 'r').read()
+	    except FileNotFoundError:
+	        return ProfileNotFound(f"File {url} does not exist")
+	elif parsed_url.scheme in ('https', 'http'):
+	    return urllib.request.urlopen(url).read().decode('utf-8')
+	else:
+	    return ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
 
 
 def run_as_a_module():
-    """
-    Since we're running this as a 'python -m archinstall' module OR
-    a nuitka3 compiled version of the project.
-    This function and the file __main__ acts as a entry point.
-    """
-    if len(sys.argv) == 1:
-        sys.argv.append('guided')
+	"""
+	Since we're running this as a 'python -m archinstall' module OR
+	a nuitka3 compiled version of the project.
+	This function and the file __main__ acts as a entry point.
+	"""
+	if len(sys.argv) == 1:
+	    sys.argv.append('guided')
 
-    try:
-        profile = find(sys.argv[1])
-    except ProfileNotFound as err:
-        print(f"Couldn't find file: {err}")
-        sys.exit(1)
+	try:
+	    profile = find(sys.argv[1])
+	except ProfileNotFound as err:
+	    print(f"Couldn't find file: {err}")
+	    sys.exit(1)
 
-    try:
-        exec(profile)  # Is this is very safe?
-    except Exception as err:
-        print(f"Failed to run profile... {err}")
-        sys.exit(1)  # Should prompt for another profile path instead
+	try:
+	    exec(profile)  # Is this is very safe?
+	except Exception as err:
+	    print(f"Failed to run profile... {err}")
+	    sys.exit(1)  # Should prompt for another profile path instead
 
 
 if __name__ == '__main__':
-    run_as_a_module()
+	run_as_a_module()

--- a/archinstall/__main__.py
+++ b/archinstall/__main__.py
@@ -1,5 +1,6 @@
+from urllib.parse import urlparse
 import archinstall, sys, os, glob
-import importlib.util
+import urllib.request
 
 # TODO: Learn the dark arts of argparse...
 #       (I summon thee dark spawn of cPython)
@@ -19,28 +20,41 @@ def find_examples():
 
 	return {os.path.basename(path): path for path in glob.glob(f'{examples}/*.py')}
 
+def find(url):
+    parsed_url = urlparse(url)
+    if not parsed_url.scheme:
+        examples = find_examples()
+        if f"{url}.py" in examples:
+          return open(examples[f"{url}.py"]).read()
+        try:
+          return open(url, 'r').read()
+        except FileNotFoundError:
+          return ProfileNotFound(f"File {url} does not exist")
+    elif parsed_url.scheme in ('https', 'http'):
+        return urllib.request.urlopen(url).read().decode('utf-8')
+    else:
+        return ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
+
 def run_as_a_module():
-	"""
-	Since we're running this as a 'python -m archinstall' module OR
-	a nuitka3 compiled version of the project.
-	This function and the file __main__ acts as a entry point.
-	"""
-	if len(sys.argv) == 1: sys.argv.append('guided')
+		"""
+		Since we're running this as a 'python -m archinstall' module OR
+		a nuitka3 compiled version of the project.
+		This function and the file __main__ acts as a entry point.
+		"""
+		if len(sys.argv) == 1: sys.argv.append('guided')
+    
+		try:
+				profile = find(sys.argv[1])
+				print(profile)
+		except ProfileNotFound as err:
+				print(f"Couldn't find file: {err}")
+				sys.exit(1)
 
-	profile = sys.argv[1]
-	library = find_examples()
-
-	if f'{profile}.py' not in library:
-		raise ProfileNotFound(f'Could not locate {profile}.py among the example files.')
-
-	# Import and execute the chosen `<profile>.py`:
-	spec = importlib.util.spec_from_file_location(
-		library[f"{profile}.py"],
-		library[f"{profile}.py"]
-	)
-	imported_path = importlib.util.module_from_spec(spec)
-	spec.loader.exec_module(imported_path)
-	sys.modules[library[f'{profile}.py']] = imported_path
+		try:
+				exec(profile) # Is this is very safe?
+		except Exception as err:
+				print(f"Failed to run profile... {err}")
+				sys.exit(1) # Should prompt for another profile path instead
 
 if __name__ == '__main__':
 	run_as_a_module()

--- a/archinstall/__main__.py
+++ b/archinstall/__main__.py
@@ -1,59 +1,68 @@
 from urllib.parse import urlparse
-import archinstall, sys, os, glob
+import archinstall
+import sys
+import os
+import glob
 import urllib.request
 
 # TODO: Learn the dark arts of argparse...
 #       (I summon thee dark spawn of cPython)
 
+
 class ProfileNotFound(BaseException):
-	pass
+    pass
+
 
 def find_examples():
-	"""
-	Used to locate the examples, bundled with the module or executable.
+    """
+    Used to locate the examples, bundled with the module or executable.
 
-	:return: {'guided.py' : './examples/guided.py', '<profile #2>' : '<path #2>'}
-	:rtype: dict
-	"""
-	cwd = os.path.abspath(f'{os.path.dirname(__file__)}')
-	examples = f"{cwd}/examples"
+    :return: {'guided.py' : './examples/guided.py', '<profile #2>' : '<path #2>'}
+    :rtype: dict
+    """
+    cwd = os.path.abspath(f'{os.path.dirname(__file__)}')
+    examples = f"{cwd}/examples"
 
-	return {os.path.basename(path): path for path in glob.glob(f'{examples}/*.py')}
+    return {os.path.basename(path): path for path in glob.glob(f'{examples}/*.py')}
+
 
 def find(url):
     parsed_url = urlparse(url)
     if not parsed_url.scheme:
         examples = find_examples()
         if f"{url}.py" in examples:
-          return open(examples[f"{url}.py"]).read()
+            return open(examples[f"{url}.py"]).read()
         try:
-          return open(url, 'r').read()
+            return open(url, 'r').read()
         except FileNotFoundError:
-          return ProfileNotFound(f"File {url} does not exist")
+            return ProfileNotFound(f"File {url} does not exist")
     elif parsed_url.scheme in ('https', 'http'):
         return urllib.request.urlopen(url).read().decode('utf-8')
     else:
         return ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
 
-def run_as_a_module():
-		"""
-		Since we're running this as a 'python -m archinstall' module OR
-		a nuitka3 compiled version of the project.
-		This function and the file __main__ acts as a entry point.
-		"""
-		if len(sys.argv) == 1: sys.argv.append('guided')
-    
-		try:
-				profile = find(sys.argv[1])
-		except ProfileNotFound as err:
-				print(f"Couldn't find file: {err}")
-				sys.exit(1)
 
-		try:
-				exec(profile) # Is this is very safe?
-		except Exception as err:
-				print(f"Failed to run profile... {err}")
-				sys.exit(1) # Should prompt for another profile path instead
+def run_as_a_module():
+    """
+    Since we're running this as a 'python -m archinstall' module OR
+    a nuitka3 compiled version of the project.
+    This function and the file __main__ acts as a entry point.
+    """
+    if len(sys.argv) == 1:
+        sys.argv.append('guided')
+
+    try:
+        profile = find(sys.argv[1])
+    except ProfileNotFound as err:
+        print(f"Couldn't find file: {err}")
+        sys.exit(1)
+
+    try:
+        exec(profile)  # Is this is very safe?
+    except Exception as err:
+        print(f"Failed to run profile... {err}")
+        sys.exit(1)  # Should prompt for another profile path instead
+
 
 if __name__ == '__main__':
-	run_as_a_module()
+    run_as_a_module()

--- a/archinstall/__main__.py
+++ b/archinstall/__main__.py
@@ -45,7 +45,6 @@ def run_as_a_module():
     
 		try:
 				profile = find(sys.argv[1])
-				print(profile)
 		except ProfileNotFound as err:
 				print(f"Couldn't find file: {err}")
 				sys.exit(1)


### PR DESCRIPTION
# Shell script calling python & support for specifying remote profiles and full paths

Adds script calling `python -m archinstall $@` in PKGBUILD.
Calling archinstall with argument `<profile>` where profile is a remote URL or a full path (not in `./examples`) folder is now possible.

## Bugs and Issues

Discussed on Discord.

## How Has This Been Tested?

Using `makepkg -sci && archinstall`. I can't test fully as QEMU crashes my desktop.
So more testing needed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
