### PR TITLE
56 log data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,4 @@ At present the core developers are (alphabetically):
  * Anton Hvornum (@Torxed)
  * Jerker Bengtsson (@jaybent)
  * Varun Madiath (@vamega)
+ * demostanis (@demostanis)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ This installer will perform the following:
 
 > **Creating your own ISO with this script on it:** Follow [ArchISO](https://wiki.archlinux.org/index.php/archiso)'s guide on how to create your own ISO or use a pre-built [guided ISO](https://hvornum.se/archiso/) to skip the python installation step, or to create auto-installing ISO templates. Further down are examples and cheat sheets on how to create different live ISO's.
 
+# Help
+
+Submit an issue on Github, or submit a post in the discord help channel.<br>
+When doing so, attach any `install-session_*.log` to the issue ticket which can be found under `~/.cache/archinstall/`.
+
 # Testing
 
 To test this without a live ISO, the simplest approach is to use a local image and create a loop device.<br>

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from .exceptions import DiskError
 from .general import *
 from .output import log, LOG_LEVELS
+from .storage import storage
 
 ROOT_DIR_PATTERN = re.compile('^.*?/devices')
 GPT = 0b00000001

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -2,6 +2,7 @@ import glob, re, os, json
 from collections import OrderedDict
 from .exceptions import DiskError
 from .general import *
+from .output import log, LOG_LEVELS
 
 ROOT_DIR_PATTERN = re.compile('^.*?/devices')
 GPT = 0b00000001
@@ -115,7 +116,7 @@ class Partition():
 			return f'Partition(path={self.path}, fs={self.filesystem}, mounted={self.mountpoint})'
 
 	def format(self, filesystem):
-		log(f'Formatting {self} -> {filesystem}')
+		log(f'Formatting {self} -> {filesystem}', level=LOG_LEVELS.Info, file=storage.get('logfile', None))
 		if filesystem == 'btrfs':
 			o = b''.join(sys_command(f'/usr/bin/mkfs.btrfs -f {self.path}'))
 			if b'UUID' not in o:
@@ -154,7 +155,7 @@ class Partition():
 
 	def mount(self, target, fs=None, options=''):
 		if not self.mountpoint:
-			log(f'Mounting {self} to {target}')
+			log(f'Mounting {self} to {target}', level=LOG_LEVELS.Info, file=storage.get('logfile', None))
 			if not fs:
 				if not self.filesystem: raise DiskError(f'Need to format (or define) the filesystem on {self} before mounting.')
 				fs = self.filesystem
@@ -216,7 +217,7 @@ class Filesystem():
 			self.add_partition('primary', start='513MiB', end='100%', format='ext4')
 
 	def add_partition(self, type, start, end, format=None):
-		log(f'Adding partition to {self.blockdevice}')
+		log(f'Adding partition to {self.blockdevice}', level=LOG_LEVELS.Info, file=storage.get('logfile', None))
 		if format:
 			return self.parted(f'{self.blockdevice.device} mkpart {type} {format} {start} {end}') == 0
 		else:

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -245,7 +245,7 @@ class sys_command():#Thread):
 			self.exit_code = 0
 
 		if self.exit_code != 0 and not self.kwargs['suppress_errors']:
-			self.log(f"'{self.raw_cmd}' did not exit gracefully, exit code {self.exit_code}.", level=LOG_LEVELS.Debug)
+			self.log(f"'{self.raw_cmd}' did not exit gracefully, exit code {self.exit_code}.", level=LOG_LEVELS.Error)
 			self.log(self.trace_log.decode('UTF-8'), level=LOG_LEVELS.Debug)
 			raise SysCallError(f"'{self.raw_cmd}' did not exit gracefully, exit code {self.exit_code}.\n{self.trace_log.decode('UTF-8')}")
 

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -192,7 +192,7 @@ class Installer():
 	def add_bootloader(self, bootloader='systemd-bootctl'):
 		self.log(f'Adding bootloader {bootloader} to {self.boot_partition}')
 
-		if bootloader == 'systemd-bootctle':
+		if bootloader == 'systemd-bootctl':
 			o = b''.join(sys_command(f'/usr/bin/arch-chroot {self.mountpoint} bootctl --no-variables --path=/boot install'))
 			with open(f'{self.mountpoint}/boot/loader/loader.conf', 'w') as loader:
 				loader.write('default arch\n')

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -52,8 +52,7 @@ class Installer():
 		self.partition = partition
 		self.boot_partition = boot_partition
 
-	@property
-	def log(self, message, *args, level=LOG_LEVELS.Debug, file=None, **kwargs):
+	def log(self, *args, level=LOG_LEVELS.Debug, file=None, **kwargs):
 		if not file:
 			if 'logfile' not in storage:
 				log_root = os.path.join(os.path.expanduser('~/'), '.cache/archinstall')
@@ -64,7 +63,7 @@ class Installer():
 
 			file = storage['logfile']
 
-		log(message, *args, level=level, file=file, **kwargs)
+		log(*args, level=level, file=file, **kwargs)
 
 	def __enter__(self, *args, **kwargs):
 		self.partition.mount(self.mountpoint)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -37,7 +37,7 @@ class Installer():
 		self.profile = profile
 		self.hostname = hostname
 		self.mountpoint = mountpoint
-		self.init_time = time.strftime('%Y-%m-%d %H:%M:%S')
+		self.init_time = time.strftime('%Y-%m-%d_%H-%M-%S')
 		self.milliseconds = int(str(time.time()).split('.')[1])
 
 		self.helper_flags = {

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -78,14 +78,14 @@ class Installer():
 			raise args[1]
 
 		if not (missing_steps := self.post_install_check()):
-			self.log('Installation completed without any errors. You may now reboot.', bg='black', fg='green')
+			self.log('Installation completed without any errors. You may now reboot.', bg='black', fg='green', level=LOG_LEVELS.Info)
 			return True
 		else:
-			self.log('Some required steps were not successfully installed/configured before leaving the installer:', bg='black', fg='red')
+			self.log('Some required steps were not successfully installed/configured before leaving the installer:', bg='black', fg='red', level=LOG_LEVELS.Warning)
 			for step in missing_steps:
-				self.log(f' - {step}', bg='black', fg='red')
-			self.log(f"Detailed error logs can be found at: {log_path}")
-			self.log(f"Submit this zip file as an issue to https://github.com/Torxed/archinstall/issues")
+				self.log(f' - {step}', bg='black', fg='red', level=LOG_LEVELS.Warning)
+			self.log(f"Detailed error logs can be found at: {log_path}", level=LOG_LEVELS.Warning)
+			self.log(f"Submit this zip file as an issue to https://github.com/Torxed/archinstall/issues", level=LOG_LEVELS.Warning)
 			return False
 
 	def post_install_check(self, *args, **kwargs):
@@ -93,15 +93,15 @@ class Installer():
 
 	def pacstrap(self, *packages, **kwargs):
 		if type(packages[0]) in (list, tuple): packages = packages[0]
-		self.log(f'Installing packages: {packages}')
+		self.log(f'Installing packages: {packages}', level=LOG_LEVELS.Info)
 
 		if (sync_mirrors := sys_command('/usr/bin/pacman -Syy')).exit_code == 0:
 			if (pacstrap := sys_command(f'/usr/bin/pacstrap {self.mountpoint} {" ".join(packages)}', **kwargs)).exit_code == 0:
 				return True
 			else:
-				self.log(f'Could not strap in packages: {pacstrap.exit_code}')
+				self.log(f'Could not strap in packages: {pacstrap.exit_code}', level=LOG_LEVELS.Info)
 		else:
-			self.log(f'Could not sync mirrors: {sync_mirrors.exit_code}')
+			self.log(f'Could not sync mirrors: {sync_mirrors.exit_code}', level=LOG_LEVELS.Info)
 
 	def set_mirrors(self, mirrors):
 		return use_mirrors(mirrors, destination=f'{self.mountpoint}/etc/pacman.d/mirrorlist')
@@ -134,13 +134,13 @@ class Installer():
 		return True
 
 	def activate_ntp(self):
-		self.log(f'Installing and activating NTP.')
+		self.log(f'Installing and activating NTP.', level=LOG_LEVELS.Info)
 		if self.pacstrap('ntp'):
 			if self.enable_service('ntpd'):
 				return True
 
 	def enable_service(self, service):
-		self.log(f'Enabling service {service}')
+		self.log(f'Enabling service {service}', level=LOG_LEVELS.Info)
 		return self.arch_chroot(f'systemctl enable {service}').exit_code == 0
 
 	def run_command(self, cmd, *args, **kwargs):
@@ -189,7 +189,7 @@ class Installer():
 		return True
 
 	def add_bootloader(self, bootloader='systemd-bootctl'):
-		self.log(f'Adding bootloader {bootloader} to {self.boot_partition}')
+		self.log(f'Adding bootloader {bootloader} to {self.boot_partition}', level=LOG_LEVELS.Info)
 
 		if bootloader == 'systemd-bootctl':
 			o = b''.join(sys_command(f'/usr/bin/arch-chroot {self.mountpoint} bootctl --no-variables --path=/boot install'))
@@ -240,17 +240,17 @@ class Installer():
 	def install_profile(self, profile):
 		profile = Profile(self, profile)
 
-		self.log(f'Installing network profile {profile}')
+		self.log(f'Installing network profile {profile}', level=LOG_LEVELS.Info)
 		return profile.install()
 
 	def enable_sudo(self, entity :str, group=False):
-		self.log(f'Enabling sudo permissions for {entity}.')
+		self.log(f'Enabling sudo permissions for {entity}.', level=LOG_LEVELS.Info)
 		with open(f'{self.mountpoint}/etc/sudoers', 'a') as sudoers:
 			sudoers.write(f'{"%" if group else ""}{entity} ALL=(ALL) ALL\n')
 		return True
 
 	def user_create(self, user :str, password=None, groups=[], sudo=False):
-		self.log(f'Creating user {user}')
+		self.log(f'Creating user {user}', level=LOG_LEVELS.Info)
 		o = b''.join(sys_command(f'/usr/bin/arch-chroot {self.mountpoint} useradd -m -G wheel {user}'))
 		if password:
 			self.user_set_pw(user, password)
@@ -263,7 +263,7 @@ class Installer():
 			self.helper_flags['user'] = True
 
 	def user_set_pw(self, user, password):
-		self.log(f'Setting password for {user}')
+		self.log(f'Setting password for {user}', level=LOG_LEVELS.Info)
 
 		if user == 'root':
 			# This means the root account isn't locked/disabled with * in /etc/passwd

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -2,6 +2,8 @@ import os
 from .exceptions import *
 from .general import *
 from .disk import Partition
+from .output import log, LOG_LEVELS
+from .storage import storage
 
 class luks2():
 	def __init__(self, partition, mountpoint, password, *args, **kwargs):
@@ -22,7 +24,10 @@ class luks2():
 		return True
 
 	def encrypt(self, partition, password, key_size=512, hash_type='sha512', iter_time=10000, key_file=None):
-		log(f'Encrypting {partition}')
+		# TODO: We should be able to integrate this into the main log some how.
+		#       Perhaps post-mortem?
+		log(f'Encrypting {partition}', level=LOG_LEVELS.Info, file=storage.get('logfile', None))
+
 		if not key_file:
 			key_file = f"/tmp/{os.path.basename(self.partition.path)}.disk_pw"  # TODO: Make disk-pw-file randomly unique?
 		if type(password) != bytes: password = bytes(password, 'UTF-8')

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -3,6 +3,7 @@ import urllib.request
 from .exceptions import *
 from .general import *
 from .output import log
+from .storage import storage
 
 def filter_mirrors_by_region(regions, destination='/etc/pacman.d/mirrorlist', tmp_dir='/root', *args, **kwargs):
 	"""

--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -2,6 +2,7 @@ import urllib.request
 
 from .exceptions import *
 from .general import *
+from .output import log
 
 def filter_mirrors_by_region(regions, destination='/etc/pacman.d/mirrorlist', tmp_dir='/root', *args, **kwargs):
 	"""
@@ -57,7 +58,7 @@ def insert_mirrors(mirrors, *args, **kwargs):
 	return True
 
 def use_mirrors(regions :dict, destination='/etc/pacman.d/mirrorlist'):
-	log(f'A new package mirror-list has been created: {destination}')
+	log(f'A new package mirror-list has been created: {destination}', level=LOG_LEVELS.Info, file=storage.get('logfile', None))
 	for region, mirrors in regions.items():
 		with open(destination, 'w') as mirrorlist:
 			for mirror in mirrors:

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -2,6 +2,7 @@ import abc
 import os
 import sys
 import logging
+from .storage import storage
 
 class LOG_LEVELS:
 	Critical = 0b001
@@ -72,25 +73,16 @@ def stylize_output(text :str, *opts, **kwargs):
 		text = '%s\x1b[%sm' % (text or '', RESET)
 	return '%s%s' % (('\x1b[%sm' % ';'.join(code_list)), text or '')
 
-GLOB_IMP_ERR_NOTIFIED = False
 def log(*args, **kwargs):
 	if 'level' in kwargs:
-		try:
-			import archinstall
-			if 'LOG_LEVEL' not in archinstall.storage:
-				archinstall.storage['LOG_LEVEL'] = LOG_LEVELS.Info
+		if 'LOG_LEVEL' not in storage:
+			storage['LOG_LEVEL'] = LOG_LEVELS.Info
 
-			if kwargs['level'] >= archinstall.storage['LOG_LEVEL']:
-				# Level on log message was Debug, but output level is set to Info.
-				# In that case, we'll drop it.
-				return None
-		except ModuleNotFoundError:
-			global GLOB_IMP_ERR_NOTIFIED
-
-			if GLOB_IMP_ERR_NOTIFIED is False:
-				print('[Error] Archinstall not found in global import path. Can not determain log level for log messages.')
-
-			GLOB_IMP_ERR_NOTIFIED = True
+		if kwargs['level'] >= storage['LOG_LEVEL']:
+			print(f"Level {kwargs['level']} is higher than storage log level {storage['LOG_LEVEL']}.")
+			# Level on log message was Debug, but output level is set to Info.
+			# In that case, we'll drop it.
+			return None
 
 	string = orig_string = ' '.join([str(x) for x in args])
 

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -97,7 +97,6 @@ def log(*args, **kwargs):
 			storage['LOG_LEVEL'] = LOG_LEVELS.Info
 
 		if kwargs['level'] > storage['LOG_LEVEL']:
-			print(f"Level {kwargs['level']} is higher than storage log level {storage['LOG_LEVEL']}.")
 			# Level on log message was Debug, but output level is set to Info.
 			# In that case, we'll drop it.
 			return None

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -82,7 +82,7 @@ def log(*args, **kwargs):
 
 	# Log to a file output unless specifically told to suppress this feature.
 	# (level has no effect on the log file, everything will be written there)
-	if 'file' in kwargs and not 'suppress' in kwargs and kwargs['suppress']:
+	if 'file' in kwargs and ('suppress' not in kwargs or kwargs['suppress'] == False):
 		if type(kwargs['file']) is str:
 			with open(kwargs['file'], 'a') as log_file:
 				log_file.write(f"{orig_string}\n")

--- a/archinstall/lib/output.py
+++ b/archinstall/lib/output.py
@@ -80,6 +80,9 @@ def log(*args, **kwargs):
 		kwargs = {'bg' : 'black', 'fg': 'white', **kwargs}
 		string = stylize_output(string, **kwargs)
 
+	if (logfile := storage.get('logfile', None)) and 'file' not in kwargs:
+		kwargs['file'] = logfile
+
 	# Log to a file output unless specifically told to suppress this feature.
 	# (level has no effect on the log file, everything will be written there)
 	if 'file' in kwargs and ('suppress' not in kwargs or kwargs['suppress'] == False):

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -5,6 +5,7 @@ from .general import multisplit, sys_command, log
 from .exceptions import *
 from .networking import *
 from .output import log, LOG_LEVELS
+from .storage import storage
 
 UPSTREAM_URL = 'https://raw.githubusercontent.com/Torxed/archinstall/master/profiles'
 

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from .general import multisplit, sys_command, log
 from .exceptions import *
 from .networking import *
+from .output import log, LOG_LEVELS
 
 UPSTREAM_URL = 'https://raw.githubusercontent.com/Torxed/archinstall/master/profiles'
 
@@ -117,7 +118,7 @@ class Profile():
 			# TODO: Remove
 			__builtins__['installation'] = self.installer
 			with instructions as runtime:
-				log(f'{self} finished successfully.', bg='black', fg='green')
+				log(f'{self} finished successfully.', bg='black', fg='green', level=LOG_LEVELS.Info, file=storage.get('logfile', None))
 		
 		return True
 

--- a/docs/help/discord.rst
+++ b/docs/help/discord.rst
@@ -1,0 +1,14 @@
+.. _help.discord:
+
+Discord
+=======
+
+There's a discord channel which is frequent by some `contributors <https://github.com/Torxed/archinstall/graphs/contributors>`_.
+
+To join the server, head over to `discord.com/archinstall <https://discord.gg/cqXU88y>`_'s server and join in.
+There's not many rules other than common sense and treat others with respect.
+
+There's the `@Party Animals` role if you want notifications of new releases which is posted in the `#Release Party` channel.
+Another thing is the `@Contributors` role which you can get by writing `!verify` and verify that you're a contributor.
+
+Hop in, I hope to see you there! : )

--- a/docs/help/issues.rst
+++ b/docs/help/issues.rst
@@ -1,0 +1,31 @@
+.. _help.issues:
+
+Issue tracker
+=============
+
+Issues should be reported over at `GitHub/issues <https://github.com/Torxed/archinstall/issues>`_.
+
+General questions, enhancements and security issues can be reported over there too.
+For quick issues or if you need help, head over the to the Discord server which has a help channel.
+
+Submitting a help ticket
+========================
+
+When submitting a help ticket, please include the *install-session_\*.log* found under *~/.cache/archinstall/* on the installation medium.
+
+.. code::bash
+
+    cd ~/.cache/archinstall
+    .
+    ├── install-session_2020-11-08_10-43-50.665316.log
+    └── workers
+        ├── 1edc2abd08261603fb78a1f6083dc74654ea6625d167744221f6bd3dec4bcd5b
+        ├── a7c8c2ceea27df2b483c493995556c86bc3e4a1befd0f6709ef6a56ff91d23f4
+        └── fadaf96c1164684cc16b374f703f7d3b959545e1ec1fb5471ace9835bf105752
+
+| You can submit the *install-session_2020-11-08_10-43-50.665316.log* in this example to the support personel.
+| They might ask you for individual worker files as well, they contain the raw output from the individual commands executed such *pacman -S ...* etc.
+
+.. warning::
+
+    Worker log-files *may* contain sensitive information such as **passwords** and **private information**. Never submit these logs without going through them manually making sure they're good for submission. Or submit parts of it that's relevant to the issue itself.

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -175,9 +175,11 @@ while 1:
 	except archinstall.RequirementError as e:
 		print(e)
 
+
 print()
 print('This is your chosen configuration:')
-print(json.dumps(archinstall.storage['_guided'], indent=4, sort_keys=True, cls=archinstall.JSON))
+archinstall.log("-- Guided template chosen (with below config) --", level=archinstall.LOG_LEVELS.Debug)
+archinstall.log(json.dumps(archinstall.storage['_guided'], indent=4, sort_keys=True, cls=archinstall.JSON), level=archinstall.LOG_LEVELS.Info)
 print()
 
 """

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -7,7 +7,7 @@ log_root = os.path.join(os.path.expanduser('~/'), '.cache/archinstall')
 if not os.path.isdir(log_root):
 	os.makedirs(log_root)
 
-init_time = time.strftime('%Y-%m-%d %H:%M:%S')
+init_time = time.strftime('%Y-%m-%d_%H-%M-%S')
 milliseconds = int(str(time.time()).split('.')[1])
 archinstall.storage['logfile'] = f"{log_root}/install-session_{init_time}.{milliseconds}.log"
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -1,5 +1,13 @@
+import getpass, time, json, sys, signal, os
 import archinstall
-import getpass, time, json, sys, signal
+
+# Setup a global log file.
+# Archinstall will honor storage['logfile'] in most of it's functions log handle.
+log_root = os.path.join(os.path.expanduser('~/'), '.cache/archinstall')
+if not os.path.isdir(log_root):
+	os.makedirs(log_root)
+
+archinstall.storage['logfile'] = f"{log_root}/install-session_{self.init_time}.{self.milliseconds}.log"
 
 """
 This signal-handler chain (and global variable)
@@ -29,7 +37,7 @@ def perform_installation(device, boot_partition, language, mirrors):
 		# Certain services might be running that affects the system during installation.
 		# Currently, only one such service is "reflector.service" which updates /etc/pacman.d/mirrorlist
 		# We need to wait for it before we continue since we opted in to use a custom mirror/region.
-		archinstall.log(f'Waiting for automatic mirror selection has completed before using custom mirrors.')
+		installation.log(f'Waiting for automatic mirror selection has completed before using custom mirrors.')
 		while 'dead' not in (status := archinstall.service_state('reflector')):
 			time.sleep(1)
 
@@ -136,6 +144,9 @@ while 1:
 		if type(profile) != str:  # Got a imported profile
 			archinstall.storage['_guided']['profile'] = profile[0]  # The second return is a module, and not a handle/object.
 			if not profile[1]._prep_function():
+				# TODO: See how we can incorporate this into
+				#       the general log flow. As this is pre-installation
+				#       session setup. Which creates the installation.log file.
 				archinstall.log(
 					' * Profile\'s preparation requirements was not fulfilled.',
 					bg='black',

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -7,7 +7,9 @@ log_root = os.path.join(os.path.expanduser('~/'), '.cache/archinstall')
 if not os.path.isdir(log_root):
 	os.makedirs(log_root)
 
-archinstall.storage['logfile'] = f"{log_root}/install-session_{self.init_time}.{self.milliseconds}.log"
+init_time = time.strftime('%Y-%m-%d %H:%M:%S')
+milliseconds = int(str(time.time()).split('.')[1])
+archinstall.storage['logfile'] = f"{log_root}/install-session_{init_time}.{milliseconds}.log"
 
 """
 This signal-handler chain (and global variable)


### PR DESCRIPTION
# Pull Request Template

## Description

Introduces **log levels** as well as a consolidated **installation log file** which is placed under `~/.cache/archinstall/`.
The format is a straight copy-paste of whatever the user is seeing during the installation procedure.



## Bugs and Issues

#56 - This should make it easier to gather log data for bug reporting

## How Has This Been Tested?

A full installation with profiles, disk encryption and user creation has been performed.

As an example:

**Test Configuration**:
* Hardware: qemu (KVM) 5.1.0-1
* Specific steps: Ran the installation with input in every field except additional packages.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable
