### PR TITLE
Fixed #63

### DIFF
--- a/archinstall/lib/packages.py
+++ b/archinstall/lib/packages.py
@@ -3,6 +3,23 @@ import ssl, json
 from .exceptions import *
 
 BASE_URL = 'https://www.archlinux.org/packages/search/json/?name={package}'
+BASE_GROUP_URL = 'https://www.archlinux.org/groups/x86_64/{group}/'
+
+def find_group(name):
+	ssl_context = ssl.create_default_context()
+	ssl_context.check_hostname = False
+	ssl_context.verify_mode = ssl.CERT_NONE
+	try:
+		response = urllib.request.urlopen(BASE_GROUP_URL.format(group=name), context=ssl_context)
+	except urllib.error.HTTPError as err:
+		if err.code == 404:
+			return False
+		else:
+			raise err
+	
+	# Just to be sure some code didn't slip through the exception
+	if response.code == 200:
+		return True
 
 def find_package(name):
 	"""
@@ -34,7 +51,7 @@ def validate_package_list(packages :list):
 	"""
 	invalid_packages = []
 	for package in packages:
-		if not find_package(package)['results']:
+		if not find_package(package)['results'] and not find_group(package):
 			invalid_packages.append(package)
 	
 	if invalid_packages:


### PR DESCRIPTION
## Description

Validate against /groups as well. There's not really a search API that I could find *(with little effort on my part to try and find it)*. So I went ahead and just check for HTTP 200 on the package URL. This won't give search functionality, but it will at least validate a group definition.

## Bugs and Issues

 * #63

## How Has This Been Tested?

Tested with `kde-applications` since there's no package with that name, only the package group.

As an example:

**Test Configuration**:
* Hardware: VirtualBox 6.1
* Specific steps: Ran installer with additional packages `nano` and `kde-applications`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
