### PR TITLE
65 systemd networkd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ SAFETY_LOCK
 **/**.pkg.*.xz
 **/**archinstall-*.tar.gz
 **/**.zst
+**/**.network
+**/**.target

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -292,7 +292,8 @@ class Installer():
 		pass
 
 	def set_keyboard_language(self, language):
-		with open(f'{self.mountpoint}/etc/vconsole.conf', 'w') as vconsole:
-			vconsole.write(f'KEYMAP={language}\n')
-			vconsole.write(f'FONT=lat9w-16\n')
+		if len(language.strip()):
+			with open(f'{self.mountpoint}/etc/vconsole.conf', 'w') as vconsole:
+				vconsole.write(f'KEYMAP={language}\n')
+				vconsole.write(f'FONT=lat9w-16\n')
 		return True

--- a/archinstall/lib/systemd.py
+++ b/archinstall/lib/systemd.py
@@ -1,0 +1,40 @@
+class Ini():
+	def __init__(self, *args, **kwargs):
+		"""
+		Limited INI handler for now.
+		Supports multiple keywords through dictionary list items.
+		"""
+		self.kwargs = kwargs
+
+	def __str__(self):
+		result = ''
+		first_row_done = False
+		for top_level in self.kwargs:
+			if first_row_done:
+				result += f"\n[{top_level}]\n"
+			else:
+				result += f"[{top_level}]\n"
+				first_row_done = True
+
+			for key, val in self.kwargs[top_level].items():
+				if type(val) == list:
+					for item in val:
+						result += f"{key}={item}\n"
+				else:
+					result += f"{key}={val}\n"
+
+		return result
+
+class Systemd(Ini):
+	def __init__(self, *args, **kwargs):
+		"""
+		Placeholder class to do systemd specific setups.
+		"""
+		super(Systemd, self).__init__(*args, **kwargs)
+
+class Networkd(Systemd):
+	def __init__(self, *args, **kwargs):
+		"""
+		Placeholder class to do systemd-network specific setups.
+		"""
+		super(Networkd, self).__init__(*args, **kwargs)

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -24,7 +24,9 @@ def generic_select(options, input_text="Select one of the above by index or abso
 		print(f"{index}: {option}")
 
 	selected_option = input(input_text)
-	if selected_option.isdigit():
+	if len(selected_option.strip()) <= 0:
+		return None
+	elif selected_option.isdigit():
 		selected_option = options[int(selected_option)]
 	elif selected_option in options:
 		pass # We gave a correct absolute value

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -49,6 +49,9 @@ def perform_installation(device, boot_partition, language, mirrors):
 			installation.set_keyboard_language(language)
 			installation.add_bootloader()
 
+			if archinstall.storage['_guided']['network']:
+				archinstall.configure_nic(**archinstall.storage['_guided']['network'])
+
 			if len(archinstall.storage['_guided']['packages']) and archinstall.storage['_guided']['packages'][0] != '':
 				installation.add_additional_packages(archinstall.storage['_guided']['packages'])
 
@@ -180,6 +183,33 @@ while 1:
 	except archinstall.RequirementError as e:
 		print(e)
 
+# Optionally configure one network interface.
+while 1:
+	interfaces = archinstall.list_interfaces()
+	archinstall.storage['_guided']['network'] = None
+
+	nic = generic_select(interfaces, "Select one network interface to configure (leave blank to skip): ")
+	if nic:
+		mode = generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ")
+		if mode == 'IP (static)':
+			while 1:
+				ip = input(f"Enter the IP and subnet for {nic} (example: 192.168.0.5/24): ").strip()
+				if ip:
+					break
+				else:
+					ArchInstall.log(
+						"You need to enter a valid IP in IP-config mode.",
+						level=archinstall.LOG_LEVELS.Warning,
+						bg='black',
+						fg='red'
+					)
+
+			gateway = input('Enter your gateway (router) IP address or leave blank for none: ').strip()
+			dns = input('Enter your DNS servers (space separated, blank for none): ').strip().split(' ')
+
+			archinstall.storage['_guided']['network'] = {'nic': nic, 'dhcp': False, 'ip': ip, 'gateway' : gateway, 'dns' : dns}
+		else:
+			archinstall.storage['_guided']['network'] = {'nic': nic}
 
 print()
 print('This is your chosen configuration:')

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -52,7 +52,7 @@ def perform_installation(device, boot_partition, language, mirrors):
 			if archinstall.storage['_guided']['network']:
 				installation.configure_nic(**archinstall.storage['_guided']['network'])
 
-			if len(archinstall.storage['_guided']['packages']) and archinstall.storage['_guided']['packages'][0] != '':
+			if archinstall.storage['_guided']['packages'] and archinstall.storage['_guided']['packages'][0] != '':
 				installation.add_additional_packages(archinstall.storage['_guided']['packages'])
 
 			if 'profile' in archinstall.storage['_guided'] and len(profile := archinstall.storage['_guided']['profile']['path'].strip()):
@@ -170,6 +170,7 @@ while 1:
 		break
 
 # Additional packages (with some light weight error handling for invalid package names)
+archinstall.storage['_guided']['packages'] = None
 while 1:
 	packages = [package for package in input('Additional packages aside from base (space separated): ').split(' ') if len(package)]
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -204,7 +204,8 @@ if nic:
 					fg='red'
 				)
 
-		if gateway = input('Enter your gateway (router) IP address or leave blank for none: ').strip()
+		if not len(gateway := input('Enter your gateway (router) IP address or leave blank for none: ').strip()):
+			gateway = None
 
 		dns = None
 		if len(dns := input('Enter your DNS servers (space separated, blank for none): ').strip()):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -204,8 +204,11 @@ if nic:
 					fg='red'
 				)
 
-		gateway = input('Enter your gateway (router) IP address or leave blank for none: ').strip()
-		dns = input('Enter your DNS servers (space separated, blank for none): ').strip().split(' ')
+		if gateway = input('Enter your gateway (router) IP address or leave blank for none: ').strip()
+
+		dns = None
+		if len(dns := input('Enter your DNS servers (space separated, blank for none): ').strip()):
+			dns = dns.split(' ')
 
 		archinstall.storage['_guided']['network'] = {'nic': nic, 'dhcp': False, 'ip': ip, 'gateway' : gateway, 'dns' : dns}
 	else:

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -50,7 +50,7 @@ def perform_installation(device, boot_partition, language, mirrors):
 			installation.add_bootloader()
 
 			if archinstall.storage['_guided']['network']:
-				archinstall.configure_nic(**archinstall.storage['_guided']['network'])
+				installation.configure_nic(**archinstall.storage['_guided']['network'])
 
 			if len(archinstall.storage['_guided']['packages']) and archinstall.storage['_guided']['packages'][0] != '':
 				installation.add_additional_packages(archinstall.storage['_guided']['packages'])

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -82,8 +82,8 @@ archinstall.sys_command(f'cryptsetup close /dev/mapper/luksloop', suppress_error
   will we continue with the actual installation steps.
 """
 
-keyboard_language = archinstall.select_language(archinstall.list_keyboard_languages())
-archinstall.set_keyboard_language(keyboard_language)
+if len(keyboard_language := archinstall.select_language(archinstall.list_keyboard_languages()).strip()):
+	archinstall.set_keyboard_language(keyboard_language)
 
 # Create a storage structure for all our information.
 # We'll print this right before the user gets informed about the formatting timer.

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -184,32 +184,33 @@ while 1:
 		print(e)
 
 # Optionally configure one network interface.
-while 1:
-	interfaces = archinstall.list_interfaces() # {MAC: Ifname}
-	archinstall.storage['_guided']['network'] = None
+#while 1:
+interfaces = archinstall.list_interfaces() # {MAC: Ifname}
+archinstall.storage['_guided']['network'] = None
 
-	nic = archinstall.generic_select(interfaces.values(), "Select one network interface to configure (leave blank to skip): ")
-	if nic:
-		mode = archinstall.generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ")
-		if mode == 'IP (static)':
-			while 1:
-				ip = input(f"Enter the IP and subnet for {nic} (example: 192.168.0.5/24): ").strip()
-				if ip:
-					break
-				else:
-					ArchInstall.log(
-						"You need to enter a valid IP in IP-config mode.",
-						level=archinstall.LOG_LEVELS.Warning,
-						bg='black',
-						fg='red'
-					)
+nic = archinstall.generic_select(interfaces.values(), "Select one network interface to configure (leave blank to skip): ")
+if nic:
+	mode = archinstall.generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ")
+	if mode == 'IP (static)':
+		while 1:
+			ip = input(f"Enter the IP and subnet for {nic} (example: 192.168.0.5/24): ").strip()
+			if ip:
+				break
+			else:
+				ArchInstall.log(
+					"You need to enter a valid IP in IP-config mode.",
+					level=archinstall.LOG_LEVELS.Warning,
+					bg='black',
+					fg='red'
+				)
 
-			gateway = input('Enter your gateway (router) IP address or leave blank for none: ').strip()
-			dns = input('Enter your DNS servers (space separated, blank for none): ').strip().split(' ')
+		gateway = input('Enter your gateway (router) IP address or leave blank for none: ').strip()
+		dns = input('Enter your DNS servers (space separated, blank for none): ').strip().split(' ')
 
-			archinstall.storage['_guided']['network'] = {'nic': nic, 'dhcp': False, 'ip': ip, 'gateway' : gateway, 'dns' : dns}
-		else:
-			archinstall.storage['_guided']['network'] = {'nic': nic}
+		archinstall.storage['_guided']['network'] = {'nic': nic, 'dhcp': False, 'ip': ip, 'gateway' : gateway, 'dns' : dns}
+	else:
+		archinstall.storage['_guided']['network'] = {'nic': nic}
+
 
 print()
 print('This is your chosen configuration:')

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -58,14 +58,15 @@ def perform_installation(device, boot_partition, language, mirrors):
 			if 'profile' in archinstall.storage['_guided'] and len(profile := archinstall.storage['_guided']['profile']['path'].strip()):
 				installation.install_profile(profile)
 
-			for user in archinstall.storage['_guided']['users']:
-				password = users[user]
+			if archinstall.storage['_guided']['users']:
+				for user in archinstall.storage['_guided']['users']:
+					password = users[user]
 
-				sudo = False
-				if 'root_pw' not in archinstall.storage['_guided_hidden'] or len(archinstall.storage['_guided_hidden']['root_pw'].strip()) == 0:
-					sudo = True
+					sudo = False
+					if 'root_pw' not in archinstall.storage['_guided_hidden'] or len(archinstall.storage['_guided_hidden']['root_pw'].strip()) == 0:
+						sudo = True
 
-				installation.user_create(user, password, sudo=sudo)
+					installation.user_create(user, password, sudo=sudo)
 
 			if 'root_pw' in archinstall.storage['_guided_hidden'] and archinstall.storage['_guided_hidden']['root_pw']:
 				installation.user_set_pw('root', archinstall.storage['_guided_hidden']['root_pw'])
@@ -124,6 +125,7 @@ new_user_text = 'Any additional users to install (leave blank for no users): '
 if len(root_pw.strip()) == 0:
 	new_user_text = 'Create a super-user with sudo privileges: '
 
+archinstall.storage['_guided']['users'] = None
 while 1:
 	new_user = input(new_user_text)
 	if len(new_user.strip()) == 0:

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -188,9 +188,9 @@ while 1:
 	interfaces = archinstall.list_interfaces()
 	archinstall.storage['_guided']['network'] = None
 
-	nic = generic_select(interfaces, "Select one network interface to configure (leave blank to skip): ")
+	nic = archinstall.generic_select(interfaces, "Select one network interface to configure (leave blank to skip): ")
 	if nic:
-		mode = generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ")
+		mode = archinstall.generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ")
 		if mode == 'IP (static)':
 			while 1:
 				ip = input(f"Enter the IP and subnet for {nic} (example: 192.168.0.5/24): ").strip()

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -135,7 +135,7 @@ while 1:
 			continue
 		break
 
-	if 'users' not in archinstall.storage['_guided']:
+	if not archinstall.storage['_guided']['users']:
 		archinstall.storage['_guided']['users'] = []
 	archinstall.storage['_guided']['users'].append(new_user)
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -51,6 +51,7 @@ def perform_installation(device, boot_partition, language, mirrors):
 
 			if archinstall.storage['_guided']['network']:
 				installation.configure_nic(**archinstall.storage['_guided']['network'])
+				installation.enable_service('systemd-networkd')
 
 			if archinstall.storage['_guided']['packages'] and archinstall.storage['_guided']['packages'][0] != '':
 				installation.add_additional_packages(archinstall.storage['_guided']['packages'])

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -208,8 +208,8 @@ if nic:
 			gateway = None
 
 		dns = None
-		if len(dns := input('Enter your DNS servers (space separated, blank for none): ').strip()):
-			dns = dns.split(' ')
+		if len(dns_input := input('Enter your DNS servers (space separated, blank for none): ').strip()):
+			dns = dns_input.split(' ')
 
 		archinstall.storage['_guided']['network'] = {'nic': nic, 'dhcp': False, 'ip': ip, 'gateway' : gateway, 'dns' : dns}
 	else:

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -185,10 +185,10 @@ while 1:
 
 # Optionally configure one network interface.
 while 1:
-	interfaces = archinstall.list_interfaces()
+	interfaces = archinstall.list_interfaces() # {MAC: Ifname}
 	archinstall.storage['_guided']['network'] = None
 
-	nic = archinstall.generic_select(interfaces, "Select one network interface to configure (leave blank to skip): ")
+	nic = archinstall.generic_select(interfaces.values(), "Select one network interface to configure (leave blank to skip): ")
 	if nic:
 		mode = archinstall.generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ")
 		if mode == 'IP (static)':


### PR DESCRIPTION
## Description

Adding *(optional)* support to configure network interfaces within the installed medium.
There's two quite limited options:

 * DHCP
 * IP (static)

To avoid unnecessary complex logic in [examples/guided.py](examples/guided.py) *(which is already getting a bit out of hand with all the user questions and loops that make it look ugly)*, I've restricted it to one interface for now. Meaning if you have a more complex setup of multiple interfaces, this will get you halfway there.

## Bugs and Issues

 * #65 

## How Has This Been Tested?

I've tested it with as many configuration options as I could think of.
There's not much error handling at the moment, so there's bound to be some edge cases here. Like putting an IP of `192.168.0.1` and skip the CIDR annotation.

As an example:

**Test Configuration**:
* Hardware: Qemu 5.1.0-1
* Specific steps: I've run the installer through 10+ different configurations, one full on install with everything entered, some steps skipped and some faulty entered parameters to try to catch as many issues as possible.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
