### PR TITLE
Attempting to select drives by size and/or id

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -89,6 +89,10 @@ class Installer():
 			self.log(f"Submit this zip file as an issue to https://github.com/Torxed/archinstall/issues", level=LOG_LEVELS.Warning)
 			return False
 
+	def mount(self, mountpoint, partition):
+		partition.mount(f'{self.mountpoint}/srv/http')
+
+
 	def post_install_check(self, *args, **kwargs):
 		return [step for step, flag in self.helper_flags.items() if flag is False]
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+import archinstall
+
+print(archinstall.harddrive(size=111.8, model='KINGSTON_SKC100S3120G'))


### PR DESCRIPTION
## Description

Adding more disk functionality, among those selecting drives based on size and ID. Also adding the option to mount something inside an installation with `installation.mount()` which auto-prepend with the installation mountpoint to ensure mount occurs inside the installation.

## How Has This Been Tested?

Been tested limited in a local VM:
