### PR TITLE
reworked kde.py to use sddm instead of hacking xinitrc

### DIFF
--- a/profiles/applications/kde.py
+++ b/profiles/applications/kde.py
@@ -1,21 +1,2 @@
 import archinstall
-
-installation.add_additional_packages("plasma-meta kde-applications-meta") # We'll support plasma-desktop (minimal) later
-
-with open(f'{installation.mountpoint}/etc/X11/xinit/xinitrc', 'r') as xinitrc:
-	xinitrc_data = xinitrc.read()
-
-# Remove Xorg defaults
-for line in xinitrc_data.split('\n'):
-	if 'twm &' in line: xinitrc_data = xinitrc_data.replace(line, f"# {line}")
-	if 'xclock' in line: xinitrc_data = xinitrc_data.replace(line, f"# {line}")
-	if 'xterm' in line: xinitrc_data = xinitrc_data.replace(line, f"# {line}")
-
-# Add the KDE specifics
-xinitrc_data += '\n'
-xinitrc_data += 'export DESKTOP_SESSION=plasma\n'
-xinitrc_data += 'exec startplasma-x11\n'
-
-# And save it
-with open(f'{installation.mountpoint}/etc/X11/xinit/xinitrc', 'w') as xinitrc:
-	xinitrc.write(xinitrc_data)
+installation.add_additional_packages("plasma-meta kde-applications-meta sddm") # We'll support plasma-desktop (minimal) later iirc sddm should be part of plasma-meta

--- a/profiles/kde.py
+++ b/profiles/kde.py
@@ -32,18 +32,4 @@ if __name__ == 'kde':
 	kde.install()
 
 	# Enable autostart of KDE for all users
-	# (there's no handy service like Gnome, so we'll hack it)
-	for root, folders, files in os.walk(f'{installation.mountpoint}/home'):
-		for home in folders:
-			with open(os.path.join(root, f"{home}/.bash_profile"), 'a') as bash_profile:
-				bash_profile.write('\n')
-				bash_profile.write('if [[ ! $DISPLAY && $XDG_VTNR -eq 1 ]]; then\n')
-				bash_profile.write('  exec startx\n') # Possibly do 'startx' only to remain logged in if KDE crashes.
-				bash_profile.write('fi\n')
-		break
-
-	with open(f'{installation.mountpoint}/etc/skel/.bash_profile', 'a') as bash_profile:
-		bash_profile.write('\n')
-		bash_profile.write('if [[ ! $DISPLAY && $XDG_VTNR -eq 1 ]]; then\n')
-		bash_profile.write('  exec startx\n') # Possibly do 'startx' only to remain logged in if KDE crashes.
-		bash_profile.write('fi\n')
+	installation.enable_service('sddm')


### PR DESCRIPTION
# use SDDM over hacking xinitrc 
## Description

this removes the hacky xinitrc implementation since kde plasma prefers sddm. this pr changes kde.py to install sddm and enable the sddm service 

## Bugs and Issues
#83 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable
