### PR TITLE
examples/guided: Enable systemd-resolved

### DIFF
--- a/examples/guided.py
+++ b/examples/guided.py
@@ -52,6 +52,7 @@ def perform_installation(device, boot_partition, language, mirrors):
 			if archinstall.storage['_guided']['network']:
 				installation.configure_nic(**archinstall.storage['_guided']['network'])
 				installation.enable_service('systemd-networkd')
+				installation.enable_service('systemd-resolved')
 
 			if archinstall.storage['_guided']['packages'] and archinstall.storage['_guided']['packages'][0] != '':
 				installation.add_additional_packages(archinstall.storage['_guided']['packages'])


### PR DESCRIPTION
If we enable systemd-networkd and do not enable systemd-resolved, the installed system
is left on a state where it has networking, but can resolve any hostnames. It is required
to have systemd-resolved enabled if any .network file has a DNS entry or is using DHCP=yes.

https://wiki.archlinux.org/index.php/Systemd-networkd#Required_services_and_setup

# Pull Request Template

Make sure you've checked out the [contribution guideline](https://github.com/Torxed/archinstall/blob/master/CONTRIBUTING.md).<br>
Most of the guidelines are not enforced, but is heavily encouraged.

## Description

Please include a summary of the change and which issue is fixed.<br>
It is also helpful to add links to online documentation or to the implementation of the code you are changing.

## Bugs and Issues

If this pull-request fixes an issue or a bug, please mention the issues with the approriate issue referece *(Example: &#35;8)*.

## How Has This Been Tested?

If possible, mention any tests you have made with the current code base included in the pull-requests.<br>
Any core-developer will also run tests, but this helps speed things up. Below is a template that can be used:

As an example:

**Test Configuration**:
* Hardware: VirtualBox 6.1
* Specific steps: Ran installer with additional packages `nano` and `wget`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable
