### PR TITLE
Change Arch Linux site URL's

### DIFF
--- a/archinstall/lib/mirrors.py
+++ b/archinstall/lib/mirrors.py
@@ -16,7 +16,7 @@ def filter_mirrors_by_region(regions, destination='/etc/pacman.d/mirrorlist', tm
 	region_list = []
 	for region in regions.split(','):
 		region_list.append(f'country={region}')
-	o = b''.join(sys_command((f"/usr/bin/wget 'https://www.archlinux.org/mirrorlist/?{'&'.join(region_list)}&protocol=https&ip_version=4&ip_version=6&use_mirror_status=on' -O {tmp_dir}/mirrorlist")))
+	o = b''.join(sys_command((f"/usr/bin/wget 'https://archlinux.org/mirrorlist/?{'&'.join(region_list)}&protocol=https&ip_version=4&ip_version=6&use_mirror_status=on' -O {tmp_dir}/mirrorlist")))
 	o = b''.join(sys_command((f"/usr/bin/sed -i 's/#Server/Server/' {tmp_dir}/mirrorlist")))
 	o = b''.join(sys_command((f"/usr/bin/mv {tmp_dir}/mirrorlist {destination}")))
 	
@@ -73,7 +73,7 @@ def re_rank_mirrors(top=10, *positionals, **kwargs):
 	return False
 
 def list_mirrors():
-	url = f"https://www.archlinux.org/mirrorlist/?protocol=https&ip_version=4&ip_version=6&use_mirror_status=on"
+	url = f"https://archlinux.org/mirrorlist/?protocol=https&ip_version=4&ip_version=6&use_mirror_status=on"
 
 	response = urllib.request.urlopen(url)
 	regions = {}

--- a/archinstall/lib/packages.py
+++ b/archinstall/lib/packages.py
@@ -2,8 +2,8 @@ import urllib.request, urllib.parse
 import ssl, json
 from .exceptions import *
 
-BASE_URL = 'https://www.archlinux.org/packages/search/json/?name={package}'
-BASE_GROUP_URL = 'https://www.archlinux.org/groups/x86_64/{group}/'
+BASE_URL = 'https://archlinux.org/packages/search/json/?name={package}'
+BASE_GROUP_URL = 'https://archlinux.org/groups/x86_64/{group}/'
 
 def find_group(name):
 	ssl_context = ssl.create_default_context()

--- a/docs/installing/binary.rst
+++ b/docs/installing/binary.rst
@@ -49,4 +49,4 @@ Simply clone or download the source, and while standing in the cloned folder `./
 
     nuitka3  --standalone --show-progress archinstall
 
-This requires the `nuitka <https://www.archlinux.org/packages/community/any/nuitka/>`_ package as well as `python3` to be installed locally.
+This requires the `nuitka <https://archlinux.org/packages/community/any/nuitka/>`_ package as well as `python3` to be installed locally.

--- a/docs/installing/guided.rst
+++ b/docs/installing/guided.rst
@@ -100,7 +100,7 @@ There is a list of profiles to choose from. If you are unsure of what any of the
 Additional packages
 ^^^^^^^^^^^^^^^^^^^
 
-Some additional packages can be installed if need be. This step allows you to list *(space separated)* officially supported packages from the `package database <https://www.archlinux.org/packages/>`_.
+Some additional packages can be installed if need be. This step allows you to list *(space separated)* officially supported packages from the `package database <https://archlinux.org/packages/>`_.
 
 .. warning::
     When selecting *(or skipping)* this step. The installation will begin and your selected hard drive will be wiped after a 5 second countdown.


### PR DESCRIPTION
Recently Arch Linux shed the www portion of its site. The links still work,
but it's a 301 redirection to archlinux.org. Changed all the URL's still pointing
to www.archlinux.org to avoid the unnecessary redirection, since on browsers the 301
is usually saved and respected, but command line tools line wget or python might not
save this and always go through the redirect.

# Pull Request Template

Make sure you've checked out the [contribution guideline](https://github.com/Torxed/archinstall/blob/master/CONTRIBUTING.md).<br>
Most of the guidelines are not enforced, but is heavily encouraged.

## Description

Please include a summary of the change and which issue is fixed.<br>
It is also helpful to add links to online documentation or to the implementation of the code you are changing.

## Bugs and Issues

If this pull-request fixes an issue or a bug, please mention the issues with the approriate issue referece *(Example: &#35;8)*.

## How Has This Been Tested?

If possible, mention any tests you have made with the current code base included in the pull-requests.<br>
Any core-developer will also run tests, but this helps speed things up. Below is a template that can be used:

As an example:

**Test Configuration**:
* Hardware: VirtualBox 6.1
* Specific steps: Ran installer with additional packages `nano` and `wget`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable
