### PR TITLE
Hardware n wifi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ SAFETY_LOCK
 **/**.network
 **/**.target
 **/**.qcow2
+**/test.py

--- a/archinstall/__init__.py
+++ b/archinstall/__init__.py
@@ -12,3 +12,4 @@ from .lib.services import *
 from .lib.packages import *
 from .lib.output import *
 from .lib.storage import *
+from .lib.hardware import *

--- a/archinstall/lib/exceptions.py
+++ b/archinstall/lib/exceptions.py
@@ -8,3 +8,5 @@ class SysCallError(BaseException):
 	pass
 class ProfileNotFound(BaseException):
 	pass
+class HardwareIncompatibilityError(BaseException):
+	pass

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -1,4 +1,5 @@
 import os
+from .general import sys_command
 from .networking import list_interfaces, enrichIfaceTypes
 
 def hasWifi():
@@ -8,3 +9,28 @@ def hasWifi():
 
 def hasUEFI():
 	return os.path.isdir('/sys/firmware/efi')
+
+def graphicsDevices():
+	cards = {}
+	for line in sys_command(f"lspci"):
+		if b' VGA ' in line:
+			_, identifier = line.split(b': ',1)
+			cards[identifier.strip().lower().decode('UTF-8')] = line
+	return cards
+
+def hasNvidiaGraphics():
+	if [x for x in graphicsDevices() if 'nvidia' in x]:
+		return True
+	return False
+
+def hasAmdGraphics():
+	if [x for x in graphicsDevices() if 'amd' in x]:
+		return True
+	return False
+
+def hasIntelGraphics():
+	if [x for x in graphicsDevices() if 'intel' in x]:
+		return True
+	return False
+
+# TODO: Add more identifiers

--- a/archinstall/lib/hardware.py
+++ b/archinstall/lib/hardware.py
@@ -1,0 +1,10 @@
+import os
+from .networking import list_interfaces, enrichIfaceTypes
+
+def hasWifi():
+	if 'WIRELESS' in enrichIfaceTypes(list_interfaces().values()).values():
+		return True
+	return False
+
+def hasUEFI():
+	return os.path.isdir('/sys/firmware/efi')

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -200,6 +200,8 @@ class Installer():
 						# base is not installed yet.
 						def post_install_enable_iwd_service(*args, **kwargs):
 							self.enable_service('iwd')
+							self.enable_service('systemd-networkd')
+							self.enable_service('systemd-resolved')
 
 						self.post_base_install.append(post_install_enable_iwd_service)
 					# Otherwise, we can go ahead and add the required package
@@ -207,6 +209,8 @@ class Installer():
 					else:
 						self.pacstrap(self.base_packages)
 						self.enable_service('iwd')
+						self.enable_service('systemd-networkd')
+						self.enable_service('systemd-resolved')
 
 				for psk in psk_files:
 					shutil.copy2(psk, f"{self.mountpoint}/var/lib/iwd/{os.path.basename(psk)}")

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -183,7 +183,7 @@ class Installer():
 		with open(f"{self.mountpoint}/etc/systemd/network/10-{nic}.network", "a") as netconf:
 			netconf.write(str(conf))
 
-	def copy_network_config(self, enable_services=False):
+	def copy_ISO_network_config(self, enable_services=False):
 		# Copy (if any) iwd password and config files
 		if os.path.isdir('/var/lib/iwd/'):
 			if (psk_files := glob.glob('/var/lib/iwd/*.psk')):

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -190,7 +190,6 @@ class Installer():
 				if not os.path.isdir(f"{self.mountpoint}/var/lib/iwd"):
 					os.makedirs(f"{self.mountpoint}/var/lib/iwd")
 
-
 				if enable_services:
 					# If we haven't installed the base yet (function called pre-maturely)
 					if self.helper_flags.get('base', False) is False:
@@ -207,7 +206,7 @@ class Installer():
 					# Otherwise, we can go ahead and add the required package
 					# and enable it's service:
 					else:
-						self.pacstrap(self.base_packages)
+						self.pacstrap('iwd')
 						self.enable_service('iwd')
 						self.enable_service('systemd-networkd')
 						self.enable_service('systemd-resolved')

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -1,4 +1,4 @@
-import os, stat, time
+import os, stat, time, shutil
 
 from .exceptions import *
 from .disk import *
@@ -48,6 +48,7 @@ class Installer():
 		}
 
 		self.base_packages = base_packages.split(' ')
+		self.post_base_install = []
 		storage['session'] = self
 
 		self.partition = partition
@@ -182,6 +183,40 @@ class Installer():
 		with open(f"{self.mountpoint}/etc/systemd/network/10-{nic}.network", "a") as netconf:
 			netconf.write(str(conf))
 
+	def copy_network_config(self, enable_services=False):
+		# Copy (if any) iwd password and config files
+		if os.path.isdir('/var/lib/iwd/'):
+			if (psk_files := glob.glob('/var/lib/iwd/*.psk')):
+				if not os.path.isdir(f"{self.mountpoint}/var/lib/iwd"):
+					os.makedirs(f"{self.mountpoint}/var/lib/iwd")
+
+				self.base_packages.append('iwd')
+
+
+				if enable_services and self.helper_flags.get('base', False) is False:
+					# This function will be called after minimal_installation() 
+					# as a hook for post-installs. This hook is only needed if
+					# base is not installed yet.
+					def post_install_enable_iwd_service(*args, **kwargs):
+						self.enable_service('iwd')
+
+					self.post_base_install.append(post_install_enable_iwd_service)
+				elif enable_services and self.helper_flags.get('base', False) is True:
+					self.enable_service('iwd')
+
+				for psk in psk_files:
+					shutil.copy2(psk, f"{self.mountpoint}/var/lib/iwd/{os.path.basename(psk)}")
+
+		# Copy (if any) systemd-networkd config files
+		if (netconfigurations := glob.glob('/etc/systemd/network/*')):
+			if not os.path.isdir(f"{self.mountpoint}/etc/systemd/network/"):
+				os.makedirs(f"{self.mountpoint}/etc/systemd/network/")
+
+			for netconf_file in netconfigurations:
+				shutil.copy2(netconf_file, f"{self.mountpoint}/etc/systemd/network/{os.path.basename(netconf_file)}")
+
+		return True
+
 	def minimal_installation(self):
 		## Add nessecary packages if encrypting the drive
 		## (encrypted partitions default to btrfs for now, so we need btrfs-progs)
@@ -220,6 +255,12 @@ class Installer():
 			sys_command(f'/usr/bin/arch-chroot {self.mountpoint} mkinitcpio -p linux')
 
 		self.helper_flags['base'] = True
+
+		# Run registered post-install hooks
+		for function in self.post_base_install:
+			self.log(f"Running post-installation hook: {function}", level=LOG_LEVELS.Info)
+			function(self)
+
 		return True
 
 	def add_bootloader(self, bootloader='systemd-bootctl'):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -49,10 +49,17 @@ def perform_installation(device, boot_partition, language, mirrors):
 			installation.set_keyboard_language(language)
 			installation.add_bootloader()
 
-			if archinstall.storage['_guided']['network']:
+			# If user selected to copy the current ISO network configuration
+			# Perform a copy of the config
+			if archinstall.storage['_guided']['network'] == 'Copy ISO network configuration to installation':
+				installation.copy_ISO_network_config(enable_services=True) # Sources the ISO network configuration to the install medium.
+
+			# Otherwise, if a interface was selected, configure that interface
+			elif archinstall.storage['_guided']['network']:
 				installation.configure_nic(**archinstall.storage['_guided']['network'])
 				installation.enable_service('systemd-networkd')
 				installation.enable_service('systemd-resolved')
+
 
 			if archinstall.storage['_guided']['packages'] and archinstall.storage['_guided']['packages'][0] != '':
 				installation.add_additional_packages(archinstall.storage['_guided']['packages'])
@@ -188,11 +195,12 @@ while 1:
 
 # Optionally configure one network interface.
 #while 1:
-interfaces = archinstall.list_interfaces() # {MAC: Ifname}
+# {MAC: Ifname}
+interfaces = {'ISO-CONFIG' : 'Copy ISO network configuration to installation', **archinstall.list_interfaces()}
 archinstall.storage['_guided']['network'] = None
 
 nic = archinstall.generic_select(interfaces.values(), "Select one network interface to configure (leave blank to skip): ")
-if nic:
+if nic and nic != 'Copy ISO network configuration to installation':
 	mode = archinstall.generic_select(['DHCP (auto detect)', 'IP (static)'], f"Select which mode to configure for {nic}: ")
 	if mode == 'IP (static)':
 		while 1:
@@ -217,7 +225,8 @@ if nic:
 		archinstall.storage['_guided']['network'] = {'nic': nic, 'dhcp': False, 'ip': ip, 'gateway' : gateway, 'dns' : dns}
 	else:
 		archinstall.storage['_guided']['network'] = {'nic': nic}
-
+elif nic:
+	archinstall.storage['_guided']['network'] = nic
 
 print()
 print('This is your chosen configuration:')


### PR DESCRIPTION
As per discussed in #82: 

![2021-01-25-153513_553x150_scrot](https://user-images.githubusercontent.com/861439/105719796-01957c00-5f23-11eb-86a4-31976af186e6.png)

Added the following, the zero-option copies the current network configuration from the ISO (live media).
It first inserts a dummy-option into the list of interfaces:
* https://github.com/Torxed/archinstall/blob/1c80a893acfb97859dd6c0f61a2cf74c03958595/examples/guided.py#L199
And if zero (injected dummy interface) is selected, it stores it as is:
* https://github.com/Torxed/archinstall/blob/1c80a893acfb97859dd6c0f61a2cf74c03958595/examples/guided.py#L229
And is then interpreted in guided during installation:
* https://github.com/Torxed/archinstall/blob/1c80a893acfb97859dd6c0f61a2cf74c03958595/examples/guided.py#L54-L55

Which in turn copies two locations from ISO to (by default) `/mnt`:
1. Copies PSK files for iwd: https://github.com/Torxed/archinstall/blob/405794d53f1f47e2a19a906dbdfa6ad39ea79c17/archinstall/lib/installer.py#L208
2. Copies .netdev/.network for systemd: https://github.com/Torxed/archinstall/blob/405794d53f1f47e2a19a906dbdfa6ad39ea79c17/archinstall/lib/installer.py#L216