### PR TITLE
installer: Make sure networkd and resolved are enabled

### DIFF
--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -224,8 +224,6 @@ class Installer():
 						# base is not installed yet.
 						def post_install_enable_iwd_service(*args, **kwargs):
 							self.enable_service('iwd')
-							self.enable_service('systemd-networkd')
-							self.enable_service('systemd-resolved')
 
 						self.post_base_install.append(post_install_enable_iwd_service)
 					# Otherwise, we can go ahead and add the required package
@@ -233,8 +231,6 @@ class Installer():
 					else:
 						self.pacstrap('iwd')
 						self.enable_service('iwd')
-						self.enable_service('systemd-networkd')
-						self.enable_service('systemd-resolved')
 
 				for psk in psk_files:
 					shutil.copy2(psk, f"{self.mountpoint}/var/lib/iwd/{os.path.basename(psk)}")
@@ -246,6 +242,19 @@ class Installer():
 
 			for netconf_file in netconfigurations:
 				shutil.copy2(netconf_file, f"{self.mountpoint}/etc/systemd/network/{os.path.basename(netconf_file)}")
+
+			if enable_services:
+				# If we haven't installed the base yet (function called pre-maturely)
+				if self.helper_flags.get('base', False) is False:
+					def post_install_enable_networkd_resolved(*args, **kwargs):
+						self.enable_service('systemd-networkd')
+						self.enable_service('systemd-resolved')
+
+					self.post_base_install.append(post_install_enable_networkd_resolved)
+				# Otherwise, we can go ahead and enable the services
+				else:
+					self.enable_service('systemd-networkd')
+					self.enable_service('systemd-resolved')
 
 		return True
 


### PR DESCRIPTION
Fixed the logic so systemd-networkd and systemd-resolved will always be enabled when the user
picks the option to copy files from the ISO. The previous behavior was to enable them only if
a wireless network was configured with iwd.

# Pull Request Template

Make sure you've checked out the [contribution guideline](https://github.com/Torxed/archinstall/blob/master/CONTRIBUTING.md).<br>
Most of the guidelines are not enforced, but is heavily encouraged.

## Description

Please include a summary of the change and which issue is fixed.<br>
It is also helpful to add links to online documentation or to the implementation of the code you are changing.

## Bugs and Issues

If this pull-request fixes an issue or a bug, please mention the issues with the approriate issue referece *(Example: &#35;8)*.

## How Has This Been Tested?

If possible, mention any tests you have made with the current code base included in the pull-requests.<br>
Any core-developer will also run tests, but this helps speed things up. Below is a template that can be used:

As an example:

**Test Configuration**:
* Hardware: VirtualBox 6.1
* Specific steps: Ran installer with additional packages `nano` and `wget`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation where possible/if applicable
