### PR TITLE
Fix multi-boot and some minor bugs

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -193,8 +193,12 @@ class Partition():
 	def detect_inner_filesystem(self, password):
 		log(f'Trying to detect inner filesystem format on {self} (This might take a while)', level=LOG_LEVELS.Info)
 		from .luks import luks2
-		with luks2(self, 'luksloop', password, auto_unmount=True) as unlocked_device:
-			return unlocked_device.filesystem
+
+		try:
+			with luks2(self, 'luksloop', password, auto_unmount=True) as unlocked_device:
+				return unlocked_device.filesystem
+		except SysCallError:
+			return None
 
 	def has_content(self):
 		temporary_mountpoint = '/tmp/'+hashlib.md5(bytes(f"{time.time()}", 'UTF-8')+os.urandom(12)).hexdigest()

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -187,7 +187,8 @@ class Partition():
 			for blockdevice in json.loads(b''.join(sys_command('lsblk -J')).decode('UTF-8'))['blockdevices']:
 				if (parent := self.find_parent_of(blockdevice, os.path.basename(self.path))):
 					return f"/dev/{parent}"
-			raise DiskError(f'Could not find appropriate parent for encrypted partition {self}')
+		#	raise DiskError(f'Could not find appropriate parent for encrypted partition {self}')
+		return self.path
 
 	def detect_inner_filesystem(self, password):
 		log(f'Trying to detect inner filesystem format on {self} (This might take a while)', level=LOG_LEVELS.Info)

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -327,6 +327,9 @@ class Partition():
 		self.mountpoint = None
 		return True
 
+	def umount(self):
+		return self.unmount()
+
 	def filesystem_supported(self):
 		"""
 		The support for a filesystem (this partition) is tested by calling

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -312,6 +312,11 @@ class Partition():
 				self.mountpoint = target
 				return True
 
+	def unmount(self):
+		if sys_command(f'/usr/bin/umount {self.path}').exit_code == 0:
+			self.mountpoint = None
+			return True
+
 	def filesystem_supported(self):
 		"""
 		The support for a filesystem (this partition) is tested by calling

--- a/archinstall/lib/exceptions.py
+++ b/archinstall/lib/exceptions.py
@@ -7,10 +7,10 @@ class UnknownFilesystemFormat(BaseException):
 class ProfileError(BaseException):
 	pass
 class SysCallError(BaseException):
-	def __init__(self, message, error_code):
+	def __init__(self, message, exit_code):
 		super(SysCallError, self).__init__(message)
 		self.message = message
-		self.error_code = error_code
+		self.exit_code = exit_code
 class ProfileNotFound(BaseException):
 	pass
 class HardwareIncompatibilityError(BaseException):

--- a/archinstall/lib/exceptions.py
+++ b/archinstall/lib/exceptions.py
@@ -7,7 +7,10 @@ class UnknownFilesystemFormat(BaseException):
 class ProfileError(BaseException):
 	pass
 class SysCallError(BaseException):
-	pass
+	def __init__(self, message, error_code):
+		super(SysCallError, self).__init__(message)
+		self.message = message
+		self.error_code = error_code
 class ProfileNotFound(BaseException):
 	pass
 class HardwareIncompatibilityError(BaseException):

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -251,7 +251,7 @@ class sys_command():#Thread):
 		if self.exit_code != 0 and not self.kwargs['suppress_errors']:
 			#self.log(self.trace_log.decode('UTF-8'), level=LOG_LEVELS.Debug)
 			#self.log(f"'{self.raw_cmd}' did not exit gracefully, exit code {self.exit_code}.", level=LOG_LEVELS.Error)
-			raise SysCallError(f"{self.trace_log.decode('UTF-8')}\n'{self.raw_cmd}' did not exit gracefully (trace log above), exit code: {self.exit_code}")
+			raise SysCallError(message=f"{self.trace_log.decode('UTF-8')}\n'{self.raw_cmd}' did not exit gracefully (trace log above), exit code: {self.exit_code}", exit_code=self.exit_code)
 
 		self.ended = time.time()
 		with open(f'{self.cwd}/trace.log', 'wb') as fh:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -363,7 +363,8 @@ class Installer():
 		return self.pacstrap(*packages)
 
 	def install_profile(self, profile):
-		profile = Profile(self, profile)
+		if type(profile) == str:
+			profile = Profile(self, profile)
 
 		self.log(f'Installing network profile {profile}', level=LOG_LEVELS.Info)
 		return profile.install()

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -69,6 +69,7 @@ class luks2():
 			cmd_handle = sys_command(f'/usr/bin/cryptsetup -q -v --type luks2 --pbkdf argon2i --hash {hash_type} --key-size {key_size} --iter-time {iter_time} --key-file {os.path.abspath(key_file)} --use-urandom luksFormat {partition.path}')
 		except SysCallError as err:
 			if err.exit_code == 256:
+				log(f'{partition} is being used, trying to unmount and crypt-close the device and running one more attempt at encrypting the device.', level=LOG_LEVELS.Debug)
 				# Partition was in use, unmount it and try again
 				partition.unmount()
 
@@ -81,9 +82,11 @@ class luks2():
 					for child in children:
 						# Unmount the child location
 						if child_mountpoint := child.get('mountpoint', None):
+							log(f'Unmounting {child_mountpoint}', level=LOG_LEVELS.Debug)
 							sys_command(f"umount {child_mountpoint}")
 
 						# And close it if possible.
+						log(f"Closing crypt device {child['name']}", level=LOG_LEVELS.Debug)
 						sys_command(f"cryptsetup close {child['name']}")
 
 				# Then try again to set up the crypt-device

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -70,7 +70,14 @@ class luks2():
 			if err.exit_code == 256:
 				# Partition was in use, unmount it and try again
 				partition.unmount()
-				sys_command(f'cryptsetup close {partition.path}')
+				try:
+					sys_command(f'cryptsetup close {partition.path}')
+				except SysCallError as err:
+					# 0 Means everything went smoothly,
+					# 1024 means the device was not found.
+					if err.exit_code not in (0, 1024):
+						raise err
+
 				cmd_handle = sys_command(f'/usr/bin/cryptsetup -q -v --type luks2 --pbkdf argon2i --hash {hash_type} --key-size {key_size} --iter-time {iter_time} --key-file {os.path.abspath(key_file)} --use-urandom luksFormat {partition.path}')
 			else:
 				raise err

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -64,8 +64,14 @@ class luks2():
 		with open(key_file, 'wb') as fh:
 			fh.write(password)
 
-		o = b''.join(sys_command(f'/usr/bin/cryptsetup -q -v --type luks2 --pbkdf argon2i --hash {hash_type} --key-size {key_size} --iter-time {iter_time} --key-file {os.path.abspath(key_file)} --use-urandom luksFormat {partition.path}'))
-		if b'Command successful.' not in o:
+		cmd_handle = sys_command(f'/usr/bin/cryptsetup -q -v --type luks2 --pbkdf argon2i --hash {hash_type} --key-size {key_size} --iter-time {iter_time} --key-file {os.path.abspath(key_file)} --use-urandom luksFormat {partition.path}')
+		if cmd_handle.exit_code == 256:
+			# Partition was in use, unmount it and 
+			partition.unmount()
+			sys_command(f'cryptsetup close {partition.path}')
+			cmd_handle = sys_command(f'/usr/bin/cryptsetup -q -v --type luks2 --pbkdf argon2i --hash {hash_type} --key-size {key_size} --iter-time {iter_time} --key-file {os.path.abspath(key_file)} --use-urandom luksFormat {partition.path}')
+
+		if b'Command successful.' not in b''.join(cmd_handle):
 			raise DiskError(f'Could not encrypt volume "{partition.path}": {o}')
 	
 		return key_file

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -83,7 +83,7 @@ class luks2():
 						# Unmount the child location
 						if child_mountpoint := child.get('mountpoint', None):
 							log(f'Unmounting {child_mountpoint}', level=LOG_LEVELS.Debug)
-							sys_command(f"umount {child_mountpoint}")
+							sys_command(f"umount -R {child_mountpoint}")
 
 						# And close it if possible.
 						log(f"Closing crypt device {child['name']}", level=LOG_LEVELS.Debug)

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -31,7 +31,7 @@ def ask_for_superuser_account(prompt='Create a required super-user with sudo pri
 			raise UserError("No superuser was created.")
 
 		password = get_password(prompt=f'Password for user {new_user}: ')
-		return {new_user: password}
+		return {new_user: {"!password" : password}}
 
 def ask_for_additional_users(prompt='Any additional users to install (leave blank for no users): '):
 	users = {}
@@ -44,9 +44,9 @@ def ask_for_additional_users(prompt='Any additional users to install (leave blan
 		password = get_password(prompt=f'Password for user {new_user}: ')
 		
 		if input("Should this user be a sudo (super) user (y/N): ").strip(' ').lower() in ('y', 'yes'):
-			super_users[new_user] = password
+			super_users[new_user] = {"!password" : password}
 		else:
-			users[new_user] = password
+			users[new_user] = {"!password" : password}
 
 	return users, super_users
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -251,7 +251,7 @@ def perform_installation_steps():
 				# Partition might be marked as encrypted due to the filesystem type crypt_LUKS
 				# But we might have omitted the encryption password question to skip encryption.
 				# In which case partition.encrypted will be true, but passwd will be false.
-				if partition.encrypted and passwd := archinstall.arguments.get('!encryption-password', None):
+				if partition.encrypted and (passwd := archinstall.arguments.get('!encryption-password', None)):
 					partition.encrypt(password=passwd)
 				else:
 					partition.format()

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -94,7 +94,7 @@ def ask_user_questions():
 								old_password = archinstall.arguments.get('!encryption-password', None)
 								if not old_password:
 									old_password = input(f'Enter the old encryption password for {partition}: ')
-									
+
 								if (autodetected_filesystem := partition.detect_inner_filesystem(old_password)):
 									new_filesystem = autodetected_filesystem
 								else:
@@ -134,8 +134,9 @@ def ask_user_questions():
 
 	# Get disk encryption password (or skip if blank)
 	if not archinstall.arguments.get('!encryption-password', None):
-		archinstall.arguments['!encryption-password'] = archinstall.get_password(prompt='Enter disk encryption password (leave blank for no encryption): ')
-	archinstall.arguments['harddrive'].encryption_password = archinstall.arguments['!encryption-password']
+		if passwd := archinstall.get_password(prompt='Enter disk encryption password (leave blank for no encryption): '):
+			archinstall.arguments['!encryption-password'] = passwd
+			archinstall.arguments['harddrive'].encryption_password = archinstall.arguments['!encryption-password']
 
 	# Get the hostname for the machine
 	if not archinstall.arguments.get('hostname', None):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -270,7 +270,6 @@ def perform_installation_steps():
 										language=archinstall.arguments['keyboard-language'],
 										mirrors=archinstall.arguments['mirror-region'])
 		else:
-			archinstall.arguments['harddrive'].partition[1].format('ext4')
 			perform_installation(device=fs.find_partition('/'),
 									boot_partition=fs.find_partition('/boot'),
 									language=archinstall.arguments['keyboard-language'],

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -308,15 +308,11 @@ def perform_installation(device, boot_partition, language, mirrors):
 			if archinstall.arguments.get('profile', None):
 				installation.install_profile(archinstall.arguments.get('profile', None))
 
-			if archinstall.arguments.get('users', None):
-				for user in archinstall.arguments.get('users'):
-					password = users[user]
-					installation.user_create(user, password, sudo=False)
-			if archinstall.arguments.get('superusers', None):
-				for user in archinstall.arguments.get('users'):
-					password = users[user]
-					installation.user_create(user, password, sudo=Tru)
-
+			for user, user_info in archinstall.arguments.get('users', {}).items():
+				installation.user_create(user, user_info["!password"], sudo=False)
+			
+			for superuser, user_info in archinstall.arguments.get('superusers', {}).items():
+				installation.user_create(superuser, user_info["!password"], sudo=True)
 
 			if (root_pw := archinstall.arguments.get('!root-password', None)) and len(root_pw):
 				installation.user_set_pw('root', root_pw)

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -305,8 +305,8 @@ def perform_installation(device, boot_partition, language, mirrors):
 			if archinstall.arguments.get('packages', None) and archinstall.arguments.get('packages', None)[0] != '':
 				installation.add_additional_packages(archinstall.arguments.get('packages', None))
 
-			if archinstall.arguments.get('profile', None) and len(profile := archinstall.arguments.get('profile').strip()):
-				installation.install_profile(profile)
+			if archinstall.arguments.get('profile', None):
+				installation.install_profile(archinstall.arguments.get('profile', None))
 
 			if archinstall.arguments.get('users', None):
 				for user in archinstall.arguments.get('users'):

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -248,8 +248,11 @@ def perform_installation_steps():
 		# which ones are safe to format, and format those.
 		for partition in archinstall.arguments['harddrive']:
 			if partition.safe_to_format():
-				if partition.encrypted:
-					partition.encrypt(password=archinstall.arguments.get('!encryption-password', None))
+				# Partition might be marked as encrypted due to the filesystem type crypt_LUKS
+				# But we might have omitted the encryption password question to skip encryption.
+				# In which case partition.encrypted will be true, but passwd will be false.
+				if partition.encrypted and passwd := archinstall.arguments.get('!encryption-password', None):
+					partition.encrypt(password=passwd)
 				else:
 					partition.format()
 			else:

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -91,7 +91,11 @@ def ask_user_questions():
 						new_filesystem = input(f"Enter a valid filesystem for {partition} (leave blank for {partition.filesystem}): ").strip(' ')
 						if len(new_filesystem) <= 0:
 							if partition.encrypted and partition.filesystem == 'crypto_LUKS':
-								if (autodetected_filesystem := partition.detect_inner_filesystem(archinstall.arguments.get('!encryption-password', None))):
+								old_password = archinstall.arguments.get('!encryption-password', None)
+								if not old_password:
+									old_password = input(f'Enter the old encryption password for {partition}: ')
+									
+								if (autodetected_filesystem := partition.detect_inner_filesystem(old_password)):
 									new_filesystem = autodetected_filesystem
 								else:
 									archinstall.log(f"Could not auto-detect the filesystem inside the encrypted volume.", fg='red')


### PR DESCRIPTION
## Description

This should fix multi-boot functionality as well as squash some random bugs.
Also brings guided.py up to the new partitioning standard and multi-boot support.

## Bugs and Issues

- #51 Multi Boot Support has been fixed
- `install_profile()` assumed a string argument, but `Profile()` can now be given as well.
- Made `add_bootloader()` a bit more robust
- Encrypted partitions will now behave more as expected.
- Users passwords are now stored as `{"username" : {"!password" : "secret"}}` instead of `{"username" : "secret"}`. This enables automatic filtering by the `JSON_Encoder` we've got. Since it filters out any key with `!` at the beginning.

**Known bug**: The profile's doesn't seam to actually be installed. I'm not quite sure. But I'll create a separate PR for that issue.

## How Has This Been Tested?

**Test Configuration**:
* Hardware: Qemu 5.2.0-3
* Specific steps: Ran through `guided.py` both with arguments to all options asked as well as a minimal enter-enter-enter-finish kind of run.

![2021-03-14-155600_1536x1179_scrot](https://user-images.githubusercontent.com/861439/111073190-12ec1500-84de-11eb-988e-226e5101aec1.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
