### PR TITLE
Torx fix profile issues

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -365,7 +365,7 @@ class Filesystem():
 		if self.blockdevice.keep_partitions is False:
 			log(f'Wiping {self.blockdevice} by using partition format {self.mode}', level=LOG_LEVELS.Debug)
 			if self.mode == GPT:
-				if sys_command(f'/usr/bin/parted -s {self.blockdevice.device} mklabel gpt',).exit_code == 0:
+				if self.raw_parted(f'{self.blockdevice.device} mklabel gpt').exit_code == 0:
 					return self
 				else:
 					raise DiskError(f'Problem setting the partition format to GPT:', f'/usr/bin/parted -s {self.blockdevice.device} mklabel gpt')

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -129,6 +129,9 @@ class BlockDevice():
 				return True
 		return False
 
+	def flush_cache(self):
+		self.part_cache = OrderedDict()
+
 class Partition():
 	def __init__(self, path, part_id=None, size=-1, filesystem=None, mountpoint=None, encrypted=False, autodetect_filesystem=True):
 		if not part_id:
@@ -366,6 +369,7 @@ class Filesystem():
 			log(f'Wiping {self.blockdevice} by using partition format {self.mode}', level=LOG_LEVELS.Debug)
 			if self.mode == GPT:
 				if self.raw_parted(f'{self.blockdevice.device} mklabel gpt').exit_code == 0:
+					self.blockdevice.flush_cache()
 					return self
 				else:
 					raise DiskError(f'Problem setting the partition format to GPT:', f'/usr/bin/parted -s {self.blockdevice.device} mklabel gpt')

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -437,6 +437,7 @@ class Filesystem():
 		log(f'Adding partition to {self.blockdevice}', level=LOG_LEVELS.Info)
 		
 		previous_partitions = self.blockdevice.partitions
+		print(previous_partitions)
 		if format:
 			partitioning = self.parted(f'{self.blockdevice.device} mkpart {type} {format} {start} {end}') == 0
 		else:
@@ -444,6 +445,8 @@ class Filesystem():
 
 		if partitioning:
 			start_wait = time.time()
+			time.sleep(2)
+			print(self.blockdevice.partitions)
 			while previous_partitions == self.blockdevice.partitions:
 				time.sleep(0.025) # Let the new partition come up in the kernel
 				if time.time() - start_wait > 10:

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -397,7 +397,7 @@ class Filesystem():
 
 	def raw_parted(self, string:str):
 		x = sys_command(f'/usr/bin/parted -s {string}')
-		o = b''.join(x)
+		log(f"'parted -s {string}' returned: {b''.join(x)}", level=LOG_LEVELS.Debug)
 		return x
 
 	def parted(self, string:str):

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -441,7 +441,6 @@ class Filesystem():
 		log(f'Adding partition to {self.blockdevice}', level=LOG_LEVELS.Info)
 		
 		previous_partitions = self.blockdevice.partitions
-		print(previous_partitions)
 		if format:
 			partitioning = self.parted(f'{self.blockdevice.device} mkpart {type} {format} {start} {end}') == 0
 		else:
@@ -449,8 +448,6 @@ class Filesystem():
 
 		if partitioning:
 			start_wait = time.time()
-			time.sleep(2)
-			print(self.blockdevice.partitions)
 			while previous_partitions == self.blockdevice.partitions:
 				time.sleep(0.025) # Let the new partition come up in the kernel
 				if time.time() - start_wait > 10:

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -352,7 +352,7 @@ class Installer():
 
 
 				if self.partition.encrypted:
-					log(f"Identifying root partition {self.partition} to boot based on disk UUID, looking for '{os.path.basename(self.partition.real_device)}'.", level=LOG_LEVELS.Info)
+					log(f"Identifying root partition {self.partition} to boot based on disk UUID, looking for '{os.path.basename(self.partition.real_device)}'.", level=LOG_LEVELS.Debug)
 					for root, folders, uids in os.walk('/dev/disk/by-uuid'):
 						for uid in uids:
 							real_path = os.path.realpath(os.path.join(root, uid))
@@ -364,7 +364,7 @@ class Installer():
 							return True
 						break
 				else:
-					log(f"Identifying root partition {self.partition} to boot based on partition UUID, looking for '{os.path.basename(self.partition.path)}'.", level=LOG_LEVELS.Info)
+					log(f"Identifying root partition {self.partition} to boot based on partition UUID, looking for '{os.path.basename(self.partition.path)}'.", level=LOG_LEVELS.Debug)
 					for root, folders, uids in os.walk('/dev/disk/by-partuuid'):
 						for uid in uids:
 							real_path = os.path.realpath(os.path.join(root, uid))

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -352,6 +352,7 @@ class Installer():
 
 
 				if self.partition.encrypted:
+					log(f"Identifying root partition {self.partition} to boot based on disk UUID, looking for '{os.path.basename(self.partition.real_device)}'.", level=LOG_LEVELS.Info)
 					for root, folders, uids in os.walk('/dev/disk/by-uuid'):
 						for uid in uids:
 							real_path = os.path.realpath(os.path.join(root, uid))
@@ -363,6 +364,7 @@ class Installer():
 							return True
 						break
 				else:
+					log(f"Identifying root partition {self.partition} to boot based on partition UUID, looking for '{os.path.basename(self.partition.path)}'.", level=LOG_LEVELS.Info)
 					for root, folders, uids in os.walk('/dev/disk/by-partuuid'):
 						for uid in uids:
 							real_path = os.path.realpath(os.path.join(root, uid))
@@ -373,6 +375,7 @@ class Installer():
 							self.helper_flags['bootloader'] = bootloader
 							return True
 						break
+
 			raise RequirementError(f"Could not identify the UUID of {self.partition}, there for {self.mountpoint}/boot/loader/entries/arch.conf will be broken until fixed.")
 		else:
 			raise RequirementError(f"Unknown (or not yet implemented) bootloader added to add_bootloader(): {bootloader}")

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -388,7 +388,7 @@ class Installer():
 		# Doing the __builtins__ replacement, ensures that the global vriable "installation"
 		# is always kept up to date. It's considered a nasty hack - but it's a safe way
 		# of ensuring 100% accuracy of archinstall session variables.
-		__builtins__['installation'] = self.installer
+		__builtins__['installation'] = self
 
 		if type(profile) == str:
 			profile = Profile(self, profile)

--- a/archinstall/lib/installer.py
+++ b/archinstall/lib/installer.py
@@ -381,6 +381,15 @@ class Installer():
 		return self.pacstrap(*packages)
 
 	def install_profile(self, profile):
+		# TODO: Replace this with a import archinstall.session instead in the profiles.
+		# The tricky thing with doing the import archinstall.session instead is that
+		# profiles might be run from a different chroot, and there's no way we can
+		# guarantee file-path safety when accessing the installer object that way.
+		# Doing the __builtins__ replacement, ensures that the global vriable "installation"
+		# is always kept up to date. It's considered a nasty hack - but it's a safe way
+		# of ensuring 100% accuracy of archinstall session variables.
+		__builtins__['installation'] = self.installer
+
 		if type(profile) == str:
 			profile = Profile(self, profile)
 

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -126,17 +126,15 @@ class Script():
 			raise ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
 
 	def load_instructions(self, namespace=None):
-		if not namespace:
-			namespace = self.namespace
+		if namespace:
+			self.namespace = namespace
 
-		self.spec = importlib.util.spec_from_file_location(namespace, self.path)
+		self.spec = importlib.util.spec_from_file_location(self.namespace, self.path)
 		imported = importlib.util.module_from_spec(self.spec)
-		sys.modules[namespace] = imported
+		sys.modules[self.namespace] = imported
 		
-		print(f"Imported {self} into sys.modules with namespace {namespace}.")
+		print(f"Imported {self} into sys.modules with namespace {self.namespace}.")
 
-		if '.py' not in namespace:
-			raise KeyError("Debugging")
 		return self
 
 	def execute(self):

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -129,15 +129,11 @@ class Script():
 		if not namespace:
 			namespace = self.namespace
 
-		if namespace in sys.modules:
-			print(f"Found {self} in sys.modules, returning cached import.")
-			return self
-
 		self.spec = importlib.util.spec_from_file_location(namespace, self.path)
 		imported = importlib.util.module_from_spec(self.spec)
 		sys.modules[namespace] = imported
 		
-		print(f"Imported {self} into sys.modules. Returning fresh copy.")
+		print(f"Imported {self} into sys.modules with namespace {namespace}.")
 		return self
 
 	def execute(self):

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -77,7 +77,7 @@ class Script():
 		self.examples = None
 		self.namespace = os.path.splitext(os.path.basename(self.path))[0]
 		self.original_namespace = self.namespace
-		log(f"Script {self} has been loaded with namespace '{self.namespace}'")
+		log(f"Script {self} has been loaded with namespace '{self.namespace}'", level=LOG_LEVELS.Debug)
 
 	def __enter__(self, *args, **kwargs):
 		self.execute()

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -76,6 +76,7 @@ class Script():
 		self.spec = None
 		self.examples = None
 		self.namespace = os.path.splitext(os.path.basename(self.path))[0]
+		print(f"Script loaded with namespace: {self.namespace}")
 
 	def __enter__(self, *args, **kwargs):
 		self.execute()

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -76,7 +76,7 @@ class Script():
 		self.spec = None
 		self.examples = None
 		self.namespace = os.path.splitext(os.path.basename(self.path))[0]
-		print(f"Script loaded with namespace: {self.namespace}")
+		print(f"Script {self} loaded with namespace: {self.namespace}")
 
 	def __enter__(self, *args, **kwargs):
 		self.execute()
@@ -126,17 +126,18 @@ class Script():
 			raise ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
 
 	def load_instructions(self, namespace=None):
-		print(f"Load instructions for {self} with namespace {namespace}")
-		if namespace:
-			self.namespace = namespace
+		if not namespace:
+			namespace = self.namespace
 
-		if '.py.py' in self.namespace:
-			raise KeyError("Debugging")
+		if namespace in sys.modules:
+			print(f"Found {self} in sys.modules, returning cached import.")
+			return self
 
-		self.spec = importlib.util.spec_from_file_location(self.namespace, self.path)
+		self.spec = importlib.util.spec_from_file_location(namespace, self.path)
 		imported = importlib.util.module_from_spec(self.spec)
-		sys.modules[self.namespace] = imported
+		sys.modules[namespace] = imported
 		
+		print(f"Imported {self} into sys.modules. Returning fresh copy.")
 		return self
 
 	def execute(self):

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -125,9 +125,7 @@ class Script():
 		else:
 			raise ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
 
-	def load_instructions(self, namespace=None, reset_namespace=False):
-		original_namespace = self.namespace
-		
+	def load_instructions(self, namespace=None):
 		if namespace:
 			self.namespace = namespace
 
@@ -136,12 +134,6 @@ class Script():
 		sys.modules[self.namespace] = imported
 		
 		print(f"Imported {self} into sys.modules with namespace {self.namespace}")
-
-		if '.py' not in self.namespace:
-			raise KeyError(f"Debugging: {self.namespace}, {reset_namespace}, {self}")
-
-		if reset_namespace:
-			self.namespace = original_namespace
 
 		return self
 
@@ -181,7 +173,7 @@ class Profile(Script):
 			#     if __name__ == 'moduleName'
 			if '__name__' in source_data and '_prep_function' in source_data:
 				print(f"Checking if {self} has _prep_function by importing with namespace {self.namespace}.py")
-				with self.load_instructions(namespace=f"{self.namespace}.py", reset_namespace=True) as imported:
+				with self.load_instructions(namespace=f"{self.namespace}.py") as imported:
 					if hasattr(imported, '_prep_function'):
 						return True
 		return False

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -125,6 +125,7 @@ class Script():
 			raise ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
 
 	def load_instructions(self, namespace=None):
+		print(f"Load instructions for {self} with namespace {namespace}")
 		if namespace:
 			self.namespace = namespace
 

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -76,6 +76,7 @@ class Script():
 		self.spec = None
 		self.examples = None
 		self.namespace = os.path.splitext(os.path.basename(self.path))[0]
+		self.original_namespace = self.namespace
 		print(f"Script {self} loaded with namespace: {self.namespace}")
 
 	def __enter__(self, *args, **kwargs):
@@ -149,7 +150,6 @@ class Script():
 class Profile(Script):
 	def __init__(self, installer, path, args={}):
 		super(Profile, self).__init__(path, installer)
-		self._cache = None
 
 	def __dump__(self, *args, **kwargs):
 		return {'path' : self.path}
@@ -158,6 +158,10 @@ class Profile(Script):
 		return f'Profile({os.path.basename(self.profile)})'
 
 	def install(self):
+		# Before installing, revert any temporary changes to the namespace.
+		# This ensures that the namespace during installation is the original initation namespace.
+		# (For instance awesome instead of aweosme.py or app-awesome.py)
+		self.namespace = self.original_namespace
 		return self.execute()
 
 	def has_prep_function(self):
@@ -207,3 +211,10 @@ class Application(Profile):
 			return self.localize_path(self.profile)
 		else:
 			raise ProfileNotFound(f"Application cannot handle scheme {parsed_url.scheme}")
+
+	def install(self):
+		# Before installing, revert any temporary changes to the namespace.
+		# This ensures that the namespace during installation is the original initation namespace.
+		# (For instance awesome instead of aweosme.py or app-awesome.py)
+		self.namespace = self.original_namespace
+		return self.execute()

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -142,7 +142,6 @@ class Script():
 		if not self.namespace in sys.modules or self.spec is None:
 			self.load_instructions()
 
-		__builtins__['installation'] = self.installer # TODO: Replace this with a import archinstall.session instead
 		self.spec.loader.exec_module(sys.modules[self.namespace])
 
 		return sys.modules[self.namespace]

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -129,6 +129,9 @@ class Script():
 		if namespace:
 			self.namespace = namespace
 
+		if '.py' in self.namespace:
+			raise KeyError("Debugging")
+
 		self.spec = importlib.util.spec_from_file_location(self.namespace, self.path)
 		imported = importlib.util.module_from_spec(self.spec)
 		sys.modules[self.namespace] = imported

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -129,8 +129,8 @@ class Script():
 		if namespace:
 			self.namespace = namespace
 
-		#if '.py' in self.namespace:
-		#	raise KeyError("Debugging")
+		if '.py' in self.namespace:
+			raise KeyError("Debugging")
 
 		self.spec = importlib.util.spec_from_file_location(self.namespace, self.path)
 		imported = importlib.util.module_from_spec(self.spec)

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -135,11 +135,14 @@ class Script():
 		imported = importlib.util.module_from_spec(self.spec)
 		sys.modules[self.namespace] = imported
 		
-		print(f"Imported {self} into sys.modules with namespace {self.namespace}.")
+		print(f"Imported {self} into sys.modules with namespace {self.namespace}")
+
+		if '.py' not in self.namespace:
+			raise KeyError(f"Debugging: {self.namespace}, {reset_namespace}, {self}")
 
 		if reset_namespace:
 			self.namespace = original_namespace
-			
+
 		return self
 
 	def execute(self):

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -129,7 +129,7 @@ class Script():
 		if namespace:
 			self.namespace = namespace
 
-		if '.py' in self.namespace:
+		if '.py.py' in self.namespace:
 			raise KeyError("Debugging")
 
 		self.spec = importlib.util.spec_from_file_location(self.namespace, self.path)
@@ -173,6 +173,7 @@ class Profile(Script):
 			# trigger a traditional:
 			#     if __name__ == 'moduleName'
 			if '__name__' in source_data and '_prep_function' in source_data:
+				print(f"Checking if {self} has _prep_function by importing with namespace {self.namespace}.py")
 				with self.load_instructions(namespace=f"{self.namespace}.py") as imported:
 					if hasattr(imported, '_prep_function'):
 						return True

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -129,8 +129,8 @@ class Script():
 		if namespace:
 			self.namespace = namespace
 
-		if '.py' in self.namespace:
-			raise KeyError("Debugging")
+		#if '.py' in self.namespace:
+		#	raise KeyError("Debugging")
 
 		self.spec = importlib.util.spec_from_file_location(self.namespace, self.path)
 		imported = importlib.util.module_from_spec(self.spec)

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -125,7 +125,9 @@ class Script():
 		else:
 			raise ProfileNotFound(f"Cannot handle scheme {parsed_url.scheme}")
 
-	def load_instructions(self, namespace=None):
+	def load_instructions(self, namespace=None, reset_namespace=False):
+		original_namespace = self.namespace
+		
 		if namespace:
 			self.namespace = namespace
 
@@ -135,6 +137,9 @@ class Script():
 		
 		print(f"Imported {self} into sys.modules with namespace {self.namespace}.")
 
+		if reset_namespace:
+			self.namespace = original_namespace
+			
 		return self
 
 	def execute(self):
@@ -173,7 +178,7 @@ class Profile(Script):
 			#     if __name__ == 'moduleName'
 			if '__name__' in source_data and '_prep_function' in source_data:
 				print(f"Checking if {self} has _prep_function by importing with namespace {self.namespace}.py")
-				with self.load_instructions(namespace=f"{self.namespace}.py") as imported:
+				with self.load_instructions(namespace=f"{self.namespace}.py", reset_namespace=True) as imported:
 					if hasattr(imported, '_prep_function'):
 						return True
 		return False

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -134,6 +134,9 @@ class Script():
 		sys.modules[namespace] = imported
 		
 		print(f"Imported {self} into sys.modules with namespace {namespace}.")
+
+		if '.py' not in namespace:
+			raise KeyError("Debugging")
 		return self
 
 	def execute(self):

--- a/archinstall/lib/profiles.py
+++ b/archinstall/lib/profiles.py
@@ -1,7 +1,7 @@
 import os, urllib.request, urllib.parse, ssl, json, re
 import importlib.util, sys, glob, hashlib
 from collections import OrderedDict
-from .general import multisplit, sys_command, log
+from .general import multisplit, sys_command
 from .exceptions import *
 from .networking import *
 from .output import log, LOG_LEVELS
@@ -77,7 +77,7 @@ class Script():
 		self.examples = None
 		self.namespace = os.path.splitext(os.path.basename(self.path))[0]
 		self.original_namespace = self.namespace
-		print(f"Script {self} loaded with namespace: {self.namespace}")
+		log(f"Script {self} has been loaded with namespace '{self.namespace}'")
 
 	def __enter__(self, *args, **kwargs):
 		self.execute()
@@ -133,8 +133,6 @@ class Script():
 		self.spec = importlib.util.spec_from_file_location(self.namespace, self.path)
 		imported = importlib.util.module_from_spec(self.spec)
 		sys.modules[self.namespace] = imported
-		
-		print(f"Imported {self} into sys.modules with namespace {self.namespace}")
 
 		return self
 
@@ -175,7 +173,6 @@ class Profile(Script):
 			# trigger a traditional:
 			#     if __name__ == 'moduleName'
 			if '__name__' in source_data and '_prep_function' in source_data:
-				print(f"Checking if {self} has _prep_function by importing with namespace {self.namespace}.py")
 				with self.load_instructions(namespace=f"{self.namespace}.py") as imported:
 					if hasattr(imported, '_prep_function'):
 						return True

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -170,7 +170,7 @@ def ask_user_questions():
 	# Check the potentially selected profiles preperations to get early checks if some additional questions are needed.
 	if archinstall.arguments['profile'] and archinstall.arguments['profile'].has_prep_function():
 		print(f"{archinstall.arguments['profile']} has prep-function, loading with namespace {archinstall.arguments['profile'].namespace}.py")
-		with archinstall.arguments['profile'].load_instructions(namespace=f"{archinstall.arguments['profile'].namespace}.py") as imported:
+		with archinstall.arguments['profile'].load_instructions(namespace=f"{archinstall.arguments['profile'].namespace}.py", reset_namespace=True) as imported:
 			if not imported._prep_function():
 				archinstall.log(
 					' * Profile\'s preparation requirements was not fulfilled.',

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -169,6 +169,7 @@ def ask_user_questions():
 
 	# Check the potentially selected profiles preperations to get early checks if some additional questions are needed.
 	if archinstall.arguments['profile'] and archinstall.arguments['profile'].has_prep_function():
+		print(f"{archinstall.arguments['profile']} has prep-function, loading with namespace {archinstall.arguments['profile'].namespace}.py")
 		with archinstall.arguments['profile'].load_instructions(namespace=f"{archinstall.arguments['profile'].namespace}.py") as imported:
 			if not imported._prep_function():
 				archinstall.log(

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -170,7 +170,7 @@ def ask_user_questions():
 	# Check the potentially selected profiles preperations to get early checks if some additional questions are needed.
 	if archinstall.arguments['profile'] and archinstall.arguments['profile'].has_prep_function():
 		print(f"{archinstall.arguments['profile']} has prep-function, loading with namespace {archinstall.arguments['profile'].namespace}.py")
-		with archinstall.arguments['profile'].load_instructions(namespace=f"{archinstall.arguments['profile'].namespace}.py", reset_namespace=True) as imported:
+		with archinstall.arguments['profile'].load_instructions(namespace=f"{archinstall.arguments['profile'].namespace}.py") as imported:
 			if not imported._prep_function():
 				archinstall.log(
 					' * Profile\'s preparation requirements was not fulfilled.',

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -169,7 +169,6 @@ def ask_user_questions():
 
 	# Check the potentially selected profiles preperations to get early checks if some additional questions are needed.
 	if archinstall.arguments['profile'] and archinstall.arguments['profile'].has_prep_function():
-		print(f"{archinstall.arguments['profile']} has prep-function, loading with namespace {archinstall.arguments['profile'].namespace}.py")
 		with archinstall.arguments['profile'].load_instructions(namespace=f"{archinstall.arguments['profile'].namespace}.py") as imported:
 			if not imported._prep_function():
 				archinstall.log(

--- a/profiles/awesome.py
+++ b/profiles/awesome.py
@@ -32,7 +32,7 @@ if __name__ == 'awesome':
 	editor = "nano"
 	filebrowser = "nemo gpicview-gtk3"
 	webbrowser = "chromium" # TODO: Ask the user to select one instead
-	utils = "openssh sshfs git htop pkgfile scrot dhclient wget libu2f-host"
+	utils = "openssh sshfs htop scrot wget"
 
 
 	installation.add_additional_packages(f"{webbrowser} {utils} {filebrowser} {editor}")


### PR DESCRIPTION
## Description

Fixes a lot of small issues introduced in the last three release candidates. Most of them are edge cases, but never the less they were obstructing normal usage.

## Bugs and Issues

* Harddrives with previous partitions matching that of the new setup, would cause unintentional hanging/crashing because the partition-er was waiting for the new layout to pop up. This was mainly caused by an issue in `BlockDevice()` keeping a cache for sanity reasons, which `Filesystem()` now properly clears when it executes `parted -s /dev/x mklabel gpt`. Since the `mklabel` should flush partitions we too flush partitions now through `blockdev.flush_cache()`.
* The global variable `installation` which is a "shadow variable" *(lack of better term)* is created prior to running profiles. This is so that profiles can access the current-running-installation through a instance variable that is accessible despite the location of the profile vs archinstall *(the library)*. Since we can not reliably say that archinstall will be a built-in library in the ENV, nor can we say that the placement of the profiles are a dead given, the only way at the moment is to defined it via `__builtins__['installation'] = current_installation`. This was previously done in the `Script()` class, since it was initiated through the installation, but since `Script()` and `Profile()` can now be imitated before a installation even begins, it's now up to the `Installation()` class to set the variable, which will be `__builtins__['installation'] = self` in this case, prior to calling `profile.install()`. Which makes more sense anyway.
* `Profile()` and `Application()` now stores the original namespace during initation. And just prior to running `.install()` and in turn `.execute()` both classes will now reset the namespace to it's original namespace. The issue here was that `has_prep_function()` modified the namespace to safely import the given profile, to not trigger any actual code. But there's no reliable way for `has_prep_function` to reset the namespace as it's called a few levels in. And `.install()` would run with a modified namespace causing the profiles to never execute fully. This solves that problem.

Also slimmed down the `awesome` profile from even more redundant packages.

## How Has This Been Tested?

**Test Configuration**:
* Hardware: Qemu 5.2.0-3
* Specific steps: Ran installer with the following configuration:
![2021-03-21-170903_1536x1179_scrot](https://user-images.githubusercontent.com/861439/111913361-15b2b100-8a6e-11eb-838f-9e4f9e55a3bf.png)

Also tried a bunch of variations where the disk was blank, partially formatted, partially encrypted and also with different user/encryption configurations and profiles.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
