### PR TITLE
Fix spelling error in filesystem choice

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -141,7 +141,7 @@ def ask_for_main_filesystem_format():
 		'f2fs' : 'f2fs'
 	}
 
-	value = generic_select(options.values(), "Select which filesystem your main partition should use (by number of name): ")
+	value = generic_select(options.values(), "Select which filesystem your main partition should use (by number or name): ")
 	return next((key for key, val in options.items() if val == value), None)
 
 def generic_select(options, input_text="Select one of the above by index or absolute value: ", sort=True):


### PR DESCRIPTION
Fixes a simple spelling error when the user is asked to select a filesystem.
"Select which filesystem your main partition should use (by number **of** name)" should be **or**.