### PR TITLE
Fixes encrypted -> non-encrypted setups

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -322,7 +322,8 @@ class Partition():
 		else:
 			raise UnknownFilesystemFormat(f"Fileformat '{filesystem}' is not yet implemented.")
 
-		self.encrypted = False if self.filesystem != 'crypto_LUKS' else True
+		if get_filesystem_type(path) == 'crypto_LUKS':
+			self.encrypted = True
 
 		return True
 

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -452,6 +452,8 @@ class Filesystem():
 		self.blockdevice.partition[1].allow_formatting = True
 
 		if encrypt_root_partition:
+			raise ValueError("moo")
+			exit(1)
 			log(f"Marking partition {self.blockdevice.partition[1]} as encrypted.", level=LOG_LEVELS.Debug)
 			self.blockdevice.partition[1].encrypted = True
 

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -322,10 +322,10 @@ class Partition():
 		else:
 			raise UnknownFilesystemFormat(f"Fileformat '{filesystem}' is not yet implemented.")
 
-		print('Checking if encrypted:', path)
-		print('Also checking:', self.real_device)
 		if get_filesystem_type(path) == 'crypto_LUKS' or get_filesystem_type(self.real_device) == 'crypto_LUKS':
 			self.encrypted = True
+		else:
+			self.encrypted = False
 
 		return True
 

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -237,11 +237,6 @@ class Partition():
 		return True if files > 0 else False
 
 	def safe_to_format(self):
-		if self.block_device and self.block_device.keep_partitions is False:
-			# If we don't intend to keep any partitions on the parent block device
-			# We're good to format.
-			return True
-
 		if self.allow_formatting is False:
 			log(f"Partition {self} is not marked for formatting.", level=LOG_LEVELS.Debug)
 			return False

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -189,8 +189,9 @@ class Partition():
 
 	@encrypted.setter
 	def encrypted(self, value :bool):
-		log(f'Marking {self} as encrypted', level=LOG_LEVELS.Debug)
-		log(f"Callstrack when marking the partition: {''.join(traceback.format_stack())}", level=LOG_LEVELS.Debug)
+		if value:
+			log(f'Marking {self} as encrypted: {value}', level=LOG_LEVELS.Debug)
+			log(f"Callstrack when marking the partition: {''.join(traceback.format_stack())}", level=LOG_LEVELS.Debug)
 		self._encrypted = value
 
 	@property

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -190,6 +190,7 @@ class Partition():
 	@encrypted.setter
 	def encrypted(self, value :bool):
 		log(f'Marking {self} as encrypted', level=LOG_LEVELS.Debug)
+		log(f"Callstrack when marking the partition: {''.join(traceback.format_stack())}", level=LOG_LEVELS.Debug)
 		self._encrypted = value
 
 	@property
@@ -453,7 +454,6 @@ class Filesystem():
 
 		if encrypt_root_partition:
 			log(f"Marking partition {self.blockdevice.partition[1]} as encrypted.", level=LOG_LEVELS.Debug)
-			log(f"Callstrack when marking the partition: {''.join(traceback.format_stack())}", level=LOG_LEVELS.Debug)
 			
 			self.blockdevice.partition[1].encrypted = True
 

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -322,8 +322,6 @@ class Partition():
 		else:
 			raise UnknownFilesystemFormat(f"Fileformat '{filesystem}' is not yet implemented.")
 
-		print('Checking if encrypted:', path)
-		print('Also checking:', self.real_device)
 		if get_filesystem_type(path) == 'crypto_LUKS' or get_filesystem_type(self.real_device) == 'crypto_LUKS':
 			self.encrypted = True
 		else:

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -1,5 +1,5 @@
 import glob, re, os, json, time, hashlib
-import pathlib
+import pathlib, traceback
 from collections import OrderedDict
 from .exceptions import DiskError
 from .general import *
@@ -452,9 +452,9 @@ class Filesystem():
 		self.blockdevice.partition[1].allow_formatting = True
 
 		if encrypt_root_partition:
-			raise ValueError("moo")
-			exit(1)
 			log(f"Marking partition {self.blockdevice.partition[1]} as encrypted.", level=LOG_LEVELS.Debug)
+			log(f"Callstrack when marking the partition: {''.join(traceback.format_stack())}", level=LOG_LEVELS.Debug)
+			
 			self.blockdevice.partition[1].encrypted = True
 
 	def add_partition(self, type, start, end, format=None):

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -237,6 +237,9 @@ class Partition():
 		return True if files > 0 else False
 
 	def safe_to_format(self):
+		if self.block_device and self.block_device.keep_partitions is True:
+			return True
+
 		if self.allow_formatting is False:
 			log(f"Partition {self} is not marked for formatting.", level=LOG_LEVELS.Debug)
 			return False

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -322,7 +322,9 @@ class Partition():
 		else:
 			raise UnknownFilesystemFormat(f"Fileformat '{filesystem}' is not yet implemented.")
 
-		if get_filesystem_type(path) == 'crypto_LUKS':
+		print('Checking if encrypted:', path)
+		print('Also checking:', self.real_device)
+		if get_filesystem_type(path) == 'crypto_LUKS' or get_filesystem_type(self.real_device) == 'crypto_LUKS':
 			self.encrypted = True
 
 		return True

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -142,8 +142,9 @@ class BlockDevice():
 			if partition in self.part_cache:
 				if self.part_cache[partition].size == old_partitions[partition].size and \
 				  self.part_cache[partition].filesystem == old_partitions[partition].filesystem:
-					print('Carrying over', self.part_cache[partition].target_mountpoint)
+					print('Carrying over', self.part_cache[partition].target_mountpoint, self.part_cache[partition].allow_formatting)
 					self.part_cache[partition].target_mountpoint = old_partitions[partition].target_mountpoint
+					self.part_cache[partition].allow_formatting = old_partitions[partition].allow_formatting
 
 class Partition():
 	def __init__(self, path :str, block_device :BlockDevice, part_id=None, size=-1, filesystem=None, mountpoint=None, encrypted=False, autodetect_filesystem=True):

--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -322,6 +322,8 @@ class Partition():
 		else:
 			raise UnknownFilesystemFormat(f"Fileformat '{filesystem}' is not yet implemented.")
 
+		print('Checking if encrypted:', path)
+		print('Also checking:', self.real_device)
 		if get_filesystem_type(path) == 'crypto_LUKS' or get_filesystem_type(self.real_device) == 'crypto_LUKS':
 			self.encrypted = True
 		else:

--- a/archinstall/lib/luks.py
+++ b/archinstall/lib/luks.py
@@ -113,7 +113,7 @@ class luks2():
 		sys_command(f'/usr/bin/cryptsetup open {partition.path} {mountpoint} --key-file {os.path.abspath(key_file)} --type luks2')
 		if os.path.islink(f'/dev/mapper/{mountpoint}'):
 			self.mapdev = f'/dev/mapper/{mountpoint}'
-			unlocked_partition = Partition(self.mapdev, encrypted=True, filesystem=get_filesystem_type(self.mapdev), autodetect_filesystem=False)
+			unlocked_partition = Partition(self.mapdev, None, encrypted=True, filesystem=get_filesystem_type(self.mapdev), autodetect_filesystem=False)
 			unlocked_partition.allow_formatting = self.partition.allow_formatting
 			return unlocked_partition
 

--- a/examples/guided.py
+++ b/examples/guided.py
@@ -247,10 +247,10 @@ def perform_installation_steps():
 	with archinstall.Filesystem(archinstall.arguments['harddrive'], archinstall.GPT) as fs:
 		# Wipe the entire drive if the disk flag `keep_partitions`is False.
 		if archinstall.arguments['harddrive'].keep_partitions is False:
-			fs.use_entire_disk(root_filesystem_type=archinstall.arguments.get('filesystem', 'btrfs'),
-								encrypt_root_partition=archinstall.arguments.get('!encryption-password', False))
-		# Otherwise, check if encryption is desired and mark the root partition as encrypted.
-		elif archinstall.arguments.get('!encryption-password', None):
+			fs.use_entire_disk(root_filesystem_type=archinstall.arguments.get('filesystem', 'btrfs'))
+		
+		# Check if encryption is desired and mark the root partition as encrypted.
+		if archinstall.arguments.get('!encryption-password', None):
 			root_partition = fs.find_partition('/')
 			root_partition.encrypted = True
 				


### PR DESCRIPTION
An issue occurred when going from a encrypted partition setup, to a non-encrypted setup.
This due to a cache issue where the installer correctly identified a partition as encrypted on launch, but that flag was never cleared when used opted out of encryption. Causing the boot-loader step to falsely identify a partition as encrypted - and tried to perform certain steps that wasn't possible.

This addresses that issue and has been tested back and fourth.