### PR TITLE
Add range check to generic_select

### DIFF
--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -198,7 +198,10 @@ def select_disk(dict_o_disks):
 			print(f"{index}: {drive} ({dict_o_disks[drive]['size'], dict_o_disks[drive].device, dict_o_disks[drive]['label']})")
 		drive = input('Select one of the above disks (by number or full path): ')
 		if drive.isdigit():
-			drive = dict_o_disks[drives[int(drive)]]
+			drive = int(drive)
+			if drive >= len(drives):
+				raise DiskError(f'Selected option "{drive}" is out of range')
+			drive = dict_o_disks[drives[drive]]
 		elif drive in dict_o_disks:
 			drive = dict_o_disks[drive]
 		else:

--- a/archinstall/lib/user_interaction.py
+++ b/archinstall/lib/user_interaction.py
@@ -170,7 +170,10 @@ def generic_select(options, input_text="Select one of the above by index or abso
 	if len(selected_option.strip()) <= 0:
 		return None
 	elif selected_option.isdigit():
-		selected_option = options[int(selected_option)]
+		selected_option = int(selected_option)
+		if selected_option >= len(options):
+			raise RequirementError(f'Selected option "{selected_option}" is out of range')
+		selected_option = options[selected_option]
 	elif selected_option in options:
 		pass # We gave a correct absolute value
 	else:


### PR DESCRIPTION
## Description

Closes #128.

## Before

```
>>> import archinstall
>>> archinstall.generic_select(['a', 'b'])
0: a
1: b
Select one of the above by index or absolute value: 2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/repos/github/archinstall/archinstall/lib/user_interaction.py", line 176, in generic_select
    selected_option = options[selected_option]
IndexError: list index out of range
>>> 
```

## After

```
>>> import archinstall
>>> archinstall.generic_select(['a', 'b'])
0: a
1: b
Select one of the above by index or absolute value: 3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/repos/github/archinstall/archinstall/lib/user_interaction.py", line 175, in generic_select
    raise RequirementError(f'Selected option "{selected_option}" is out of range')
archinstall.lib.exceptions.RequirementError: Selected option "3" is out of range
>>> 
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code to the best of my abilities
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation where possible/if applicable