### PR TITLE
Fix doc issues

### DIFF
--- a/docs/examples/python.rst
+++ b/docs/examples/python.rst
@@ -9,9 +9,9 @@ The way the library is invoked in module mode is limited to executing scripts un
 It's there for important to place any script or profile you wish to invoke in the examples folder prior to building and installing.
 
 Pre-requisites
--------------
+--------------
 
-We'll assume you've followed the `installing.python.manual`_ method.
+We'll assume you've followed the :ref:`installing.python.manual` method.
 Before actually installing the library, you will need to place your custom installer-scripts under `./archinstall/examples/` as a python file.
 
 More on how you create these in the next section.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ python-archinstall Documentation
 ================================
 
 | **python-archinstall** *(or, archinstall for short)* is a helper library to install Arch Linux and manage services, packages and other things.
-| It comes packaged with different pre-configured installers, such as the `installing.guided`_ installer.
+| It comes packaged with different pre-configured installers, such as the :ref:`guided <installing.guided>` installer.
 | 
 | A demo can be viewed here: `https://www.youtube.com/watch?v=9Xt7X_Iqg6E <https://www.youtube.com/watch?v=9Xt7X_Iqg6E>`_ which uses the default guided installer.
 

--- a/docs/installing/guided.rst
+++ b/docs/installing/guided.rst
@@ -100,6 +100,8 @@ Default is :code:`Archinstall`
 The hostname in which the machine will identify itself on the local network.
 This step is optional, but a default hostname of `Archinstall` will be set if none is selected.
 
+.. _root_password:
+
 Root password
 -------------
 
@@ -115,7 +117,7 @@ Super User (sudo)
 -----------------
 
 .. warning::
-    This step only applies if you correctly skipped the previous step :ref:`root_password`_ which also makes this step mandatory.
+    This step only applies if you correctly skipped :ref:`the previous step <root_password>` which also makes this step mandatory.
 
 If the previous step was skipped, and only if it is skipped.
 This step enables you to create a :code:`sudo` enabled user with a password.

--- a/docs/installing/python.rst
+++ b/docs/installing/python.rst
@@ -44,7 +44,7 @@ Or as a user module:
 
 Which will allow you to start using the library.
 
-.. _installing.python.manual
+.. _installing.python.manual:
 
 Manual installation
 -------------------

--- a/docs/installing/python.rst
+++ b/docs/installing/python.rst
@@ -10,7 +10,7 @@ But the library can be installed manually as well.
     This is not required if you're running archinstall on a pre-built ISO. The installation is only required if you're creating your own scripted installations.
 
 Using pacman
-----------
+------------
 
 Archinstall is on the `official repositories <https://wiki.archlinux.org/index.php/Official_repositories>`_.
 


### PR DESCRIPTION
## Description

This should try to fix the error and warning of documentation which produced during building.

## Bugs and Issues

Document building log (picked up):
  archinstall/docs/examples/python.rst:12: WARNING: Title underline too short.
  archinstall/docs/examples/python.rst:14: WARNING: Unknown target name: "installing.python.manual".
  archinstall/docs/index.rst:5: WARNING: Unknown target name: "installing.guided".
  archinstall/docs/installing/guided.rst:118: WARNING: Mismatch: both interpreted text role prefix and reference suffix.
  archinstall/docs/installing/python.rst:13: WARNING: Title underline too short.

## How Has This Been Tested?

I builded successfully changed rst (with `make html`), and checked outputed html.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation where possible/if applicable
