### PR TITLE
Support passing commands as lists

### DIFF
--- a/archinstall/lib/disk.py
+++ b/archinstall/lib/disk.py
@@ -72,7 +72,7 @@ class BlockDevice():
 			raise DiskError(f'Could not locate backplane info for "{self.path}"')
 
 		if self.info['type'] == 'loop':
-			for drive in json.loads(b''.join(sys_command(f'losetup --json', hide_from_log=True)).decode('UTF_8'))['loopdevices']:
+			for drive in json.loads(b''.join(sys_command(['losetup', '--json'], hide_from_log=True)).decode('UTF_8'))['loopdevices']:
 				if not drive['name'] == self.path: continue
 
 				return drive['back-file']
@@ -88,10 +88,10 @@ class BlockDevice():
 
 	@property
 	def partitions(self):
-		o = b''.join(sys_command(f'partprobe {self.path}'))
+		o = b''.join(sys_command(['partprobe', self.path]))
 
 		#o = b''.join(sys_command('/usr/bin/lsblk -o name -J -b {dev}'.format(dev=dev)))
-		o = b''.join(sys_command(f'/usr/bin/lsblk -J {self.path}'))
+		o = b''.join(sys_command(['/usr/bin/lsblk', '-J', self.path]))
 
 		if b'not a block device' in o:
 			raise DiskError(f'Can not read partitions off something that isn\'t a block device: {self.path}')
@@ -202,7 +202,7 @@ class Partition():
 		if not self._encrypted:
 			return self.path
 		else:
-			for blockdevice in json.loads(b''.join(sys_command('lsblk -J')).decode('UTF-8'))['blockdevices']:
+			for blockdevice in json.loads(b''.join(sys_command(['lsblk', '-J'])).decode('UTF-8'))['blockdevices']:
 				if (parent := self.find_parent_of(blockdevice, os.path.basename(self.path))):
 					return f"/dev/{parent}"
 		#	raise DiskError(f'Could not find appropriate parent for encrypted partition {self}')

--- a/archinstall/lib/general.py
+++ b/archinstall/lib/general.py
@@ -86,11 +86,19 @@ class sys_command():#Thread):
 		if kwargs['emulate']:
 			self.log(f"Starting command '{cmd}' in emulation mode.", level=LOG_LEVELS.Debug)
 
-		self.raw_cmd = cmd
-		try:
-			self.cmd = shlex.split(cmd)
-		except Exception as e:
-			raise ValueError(f'Incorrect string to split: {cmd}\n{e}')
+		if type(cmd) is list:
+			# if we get a list of arguments
+			self.raw_cmd = shlex.join(cmd)
+			self.cmd = cmd
+		else:
+			# else consider it a single shell string
+			# this should only be used if really necessary
+			self.raw_cmd = cmd
+			try:
+				self.cmd = shlex.split(cmd)
+			except Exception as e:
+				raise ValueError(f'Incorrect string to split: {cmd}\n{e}')
+
 		self.args = args
 		self.kwargs = kwargs
 


### PR DESCRIPTION
## Description

Related to  #143, instead of quoting and unquoting the argument list we can now simply pass the argument list directly to `os.execv`. I've converted some easy spots but doing this for the whole codebase takes some consideration. Eventually removing the old interface would close a whole class of possible bugs/vulnerabilities.

## How Has This Been Tested?

```
% python                           
Python 3.9.2 (default, Feb 20 2021, 18:40:11) 
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import archinstall
>>> archinstall.lib.general.sys_command('ls /etc/passwd /etc/wgetrc')
(['/usr/bin/ls', '/etc/passwd', '/etc/wgetrc'], b'/etc/passwd  /etc/wgetrc\r\n')
>>> archinstall.lib.general.sys_command(['ls', '/etc/passwd', '/etc/wgetrc'])
(['/usr/bin/ls', '/etc/passwd', '/etc/wgetrc'], b'/etc/passwd  /etc/wgetrc\r\n')
>>> 
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code to the best of my abilities
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation where possible/if applicable
