### PR TITLE
ci(iso-build): use new build_iso.sh path after move

### DIFF
--- a/.github/workflows/iso-build.yaml
+++ b/.github/workflows/iso-build.yaml
@@ -32,7 +32,7 @@ jobs:
       - run: cat /etc/os-release
       - run: pacman-key --init
       - run: pacman --noconfirm -Sy archlinux-keyring
-      - run: ./build_iso.sh
+      - run: ./test_tooling/mkarchiso/build_iso.sh
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Arch Live ISO


### PR DESCRIPTION
Tiny follow-up to my comment on archlinux/archinstall#4539 — updates the workflow so the runner finds `build_iso.sh` at its new location.

```diff
@@ -32,7 +32,7 @@ jobs:
       - run: pacman-key --init
       - run: pacman --noconfirm -Sy archlinux-keyring
-      - run: ./build_iso.sh
+      - run: ./test_tooling/mkarchiso/build_iso.sh
```

The script does `cp -r .` into the archive, so CWD has to remain the repo root — just updating the invocation path is enough, no `working-directory` workaround needed.

After this lands, the `Build Arch ISO with ArchInstall Commit` job should get past the script-not-found failure and actually attempt the full build, which will tell us whether the mkosi reorganization broke the mkarchiso path for any *other* reason.